### PR TITLE
refactor: :recycle: Util.Time 확장성 있도록 개편, 관련 로직들 수정

### DIFF
--- a/app/src/home/home.service.ts
+++ b/app/src/home/home.service.ts
@@ -1,34 +1,31 @@
 import { Injectable } from '@nestjs/common';
 import { UserRanking } from 'src/common/models/common.user.model';
 import { ScaleTeamsService } from 'src/scaleTeams/scaleTeams.service';
-import { Util } from 'src/util';
+import { Time } from 'src/util';
 
 @Injectable()
 export class HomeService {
   constructor(private scaleTeamService: ScaleTeamsService) {}
 
   async currWeekEvalCnt(): Promise<number> {
-    const currDate = Util.Time.currDate();
-    // todo: test 용도
-    currDate.setDate(-7);
-    const startOfWeek = Util.Time.startOfWeek(currDate);
+    const currDate = Time.curr();
+    const currWeek = Time.startOfWeek(currDate);
+    const nextWeek = Time.moveWeek(currWeek, 1);
 
     return await this.scaleTeamService.getEvalCount({
-      beginAt: { $gte: startOfWeek },
+      beginAt: { $gte: currWeek, $lt: nextWeek },
+      filledAt: { $ne: null },
     });
   }
 
   async lastWeekEvalCnt(): Promise<number> {
-    const currDate = Util.Time.currDate();
-
-    const startOfCurrWeek = Util.Time.startOfWeek(currDate);
-    const startOfLastWeek = Util.Time.startOfLastWeek(currDate);
+    const currDate = Time.curr();
+    const currWeek = Time.startOfWeek(currDate);
+    const lastWeek = Time.moveWeek(currWeek, -1);
 
     return await this.scaleTeamService.getEvalCount({
-      beginAt: {
-        $gte: startOfLastWeek,
-        $lt: startOfCurrWeek,
-      },
+      beginAt: { $gte: lastWeek, $lt: currWeek },
+      filledAt: { $ne: null },
     });
   }
 
@@ -37,11 +34,13 @@ export class HomeService {
   }
 
   async monthlyEvalCntRank(): Promise<UserRanking[]> {
-    const currDate = Util.Time.currDate();
-    const startOfMonth = Util.Time.startOfMonth(currDate);
+    const currDate = Time.curr();
+    const currMonth = Time.startOfMonth(currDate);
+    const nextMonth = Time.moveMonth(currMonth, 1);
 
     return this.scaleTeamService.getEvalCountRank({
-      beginAt: { $gte: startOfMonth },
+      beginAt: { $gte: currMonth, $lt: nextMonth },
+      filledAt: { $ne: null },
     });
   }
 }

--- a/app/src/personalEval/personal.eval.service.ts
+++ b/app/src/personalEval/personal.eval.service.ts
@@ -1,33 +1,30 @@
 import { Injectable } from '@nestjs/common';
 import { ScaleTeamsService } from 'src/scaleTeams/scaleTeams.service';
-import { Util } from 'src/util';
+import { Time } from 'src/util';
 
 @Injectable()
 export class PersonalEvalService {
   constructor(private scaleTeamService: ScaleTeamsService) {}
 
   async currMonthCount(uid: number): Promise<number> {
-    const currDate = Util.Time.currDate();
-    const startOfMonth = Util.Time.startOfMonth(currDate);
+    const currDate = Time.curr();
+    const currMonth = Time.startOfMonth(currDate);
 
     return await this.scaleTeamService.getEvalCount({
       'corrector.id': uid,
-      beginAt: { $gte: startOfMonth },
+      beginAt: { $gte: currMonth },
       filledAt: { $ne: null },
     });
   }
 
   async lastMonthCount(uid: number): Promise<number> {
-    const currDate = Util.Time.currDate();
-    const startOfMonth = Util.Time.startOfMonth(currDate);
-    const startOfLastMonth = Util.Time.startOfLastMonth(currDate);
+    const currDate = Time.curr();
+    const currMonth = Time.startOfMonth(currDate);
+    const lastMonth = Time.moveMonth(currMonth, -1);
 
     return await this.scaleTeamService.getEvalCount({
       'corrector.id': uid,
-      beginAt: {
-        $gte: startOfLastMonth,
-        $lt: startOfMonth,
-      },
+      beginAt: { $gte: lastMonth, $lt: currMonth },
       filledAt: { $ne: null },
     });
   }

--- a/app/src/scaleTeams/db/scaleTeams.database.schema.ts
+++ b/app/src/scaleTeams/db/scaleTeams.database.schema.ts
@@ -122,8 +122,8 @@ export class scale_team {
   @Prop({ required: false, type: Object })
   truant: object;
 
-  @Prop({ required: true, type: String })
-  filledAt: string | null;
+  @Prop({ required: true })
+  filledAt?: Date;
 
   @Prop({ required: false, type: [Object] })
   questions_withAnswers: object[];

--- a/app/src/scaleTeams/db/scaleTeams.database.schema.ts
+++ b/app/src/scaleTeams/db/scaleTeams.database.schema.ts
@@ -122,7 +122,7 @@ export class scale_team {
   @Prop({ required: false, type: Object })
   truant: object;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   filledAt?: Date;
 
   @Prop({ required: false, type: [Object] })

--- a/app/src/scaleTeams/scaleTeams.service.ts
+++ b/app/src/scaleTeams/scaleTeams.service.ts
@@ -4,7 +4,7 @@ import type { FilterQuery, Model } from 'mongoose';
 import type { AggrNumeric } from 'src/common/db/common.db.aggregation';
 import { UserRanking } from 'src/common/models/common.user.model';
 import { EvalLogs } from 'src/evalLogs/models/evalLogs.model';
-import { Util } from 'src/util';
+import { Time } from 'src/util';
 import { scale_team } from './db/scaleTeams.database.schema';
 
 @Injectable()
@@ -129,7 +129,7 @@ export class ScaleTeamsService {
       })
       .project({
         _id: 0,
-        value: { $round: { $divide: ['$value', Util.Time.MIN] } },
+        value: { $round: { $divide: ['$value', Time.MIN] } },
       })
       .exec();
 

--- a/app/src/score/score.service.ts
+++ b/app/src/score/score.service.ts
@@ -35,9 +35,7 @@ export class ScoreService {
     const aggregate = this.scoreModel.aggregate<CoalitionScore>();
 
     return await aggregate
-      .match({
-        coalitionsUserId: { $ne: null },
-      })
+      .match({ coalitionsUserId: { $ne: null } })
       .group({ _id: '$coalitionId', value: { $sum: '$value' } })
       // todo: 이거 해야하나?
       .project({ _id: 0, coalitionId: '$_id', value: 1 })

--- a/app/src/total/total.service.ts
+++ b/app/src/total/total.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ScaleTeamsService } from 'src/scaleTeams/scaleTeams.service';
 import { ScoreService } from 'src/score/score.service';
 import { ScoreRecords, TotalScore } from './models/total.model';
-import { Util } from 'src/util';
+import { Time } from 'src/util';
 import { UserRanking } from 'src/common/models/common.user.model';
 
 @Injectable()
@@ -18,10 +18,7 @@ export class TotalService {
 
     return coalitionScores.map(
       ({ coalitionId, value }): TotalScore => ({
-        coalition: {
-          id: coalitionId,
-          name: coalitionId,
-        },
+        coalition: { id: coalitionId, name: coalitionId },
         score: value,
       }),
     );
@@ -31,34 +28,27 @@ export class TotalService {
     // todo
     const coalitionIds = [85, 86, 87, 88];
 
-    // todo: time
-    const currDate = Util.Time.currDate();
-    const beforeOneYear = Util.Time.startOfMonth(currDate);
-    beforeOneYear.setMonth(currDate.getMonth() - 12);
+    const currDate = Time.curr();
+    const lastYear = Time.startOfMonth(Time.moveMonth(currDate, -11));
 
     const scores = await this.scoreService.getScoreRecords(
-      beforeOneYear,
+      lastYear,
       currDate,
       coalitionIds,
     );
 
     return scores.map(({ coalitionId, records }) => ({
-      coalition: {
-        id: coalitionId,
-        name: coalitionId,
-      },
+      coalition: { id: coalitionId, name: coalitionId },
       records: records,
     }));
   }
 
   async monthlyScoreRanks(): Promise<UserRanking[]> {
-    const currDate = Util.Time.currDate();
-    const startOfMonth = Util.Time.startOfMonth(currDate);
-    // todo: time
-    const lastOfMonth = new Date(startOfMonth);
-    lastOfMonth.setMonth(1 + startOfMonth.getMonth());
+    const currDate = Time.curr();
+    const currMonth = Time.startOfMonth(currDate);
+    const nextMonth = Time.moveMonth(currMonth, 1);
 
-    return await this.scoreService.getScoreRanks(startOfMonth, lastOfMonth, 3);
+    return await this.scoreService.getScoreRanks(currMonth, nextMonth, 3);
   }
 
   async totalEvalCount(): Promise<number> {

--- a/app/src/util/index.ts
+++ b/app/src/util/index.ts
@@ -1,5 +1,3 @@
 import { Time } from './time';
 
-export const Util = {
-  Time,
-} as const;
+export { Time };

--- a/app/src/util/time.ts
+++ b/app/src/util/time.ts
@@ -1,27 +1,14 @@
-/**
- * 초기 기획 기준, date 관련 함수들을 추상화 시켜서 만들 필요가 없다고 판단했기 때문에, 특정 목적에
- * 맞게만 구현을 했습니다. 추후 이 기능이 확장이 되면 추상화해서 리팩토링 하는 것을 권합니다.
- */
-
 const SEC = 1000;
 const MIN = SEC * 60;
 const HOUR = MIN * 60;
 const DAY = HOUR * 24;
 const WEEK = DAY * 7;
 
-const getFlooredDate = (date: Date): Date => {
-  const copy = new Date(date);
-  copy.setHours(0, 0, 0, 0);
-  return date;
-};
-
-const getStartOfWeek = (date: Date): Date =>
-  getFlooredDate(new Date(date.getTime() - date.getDay() * DAY));
-
-const getStartOfMonth = (date: Date): Date =>
-  new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
-
-//todo: timezone setting
+/**
+ * @description 사용 시 sudo timedatectl 로 TimeZone 확인해야 합니다.
+ * 모든 함수는 local time 기준 입니다.
+ * 모든 함수는 원본을 변경하지 않습니다.
+ */
 export const Time = {
   SEC,
   MIN,
@@ -29,35 +16,53 @@ export const Time = {
   DAY,
   WEEK,
 
-  currDate: (): Date => new Date(),
+  // todo: 개발 용도. 완료 후 인자 제거 필요합니다.
+  curr: (): Date => new Date('2023-04-10T00:00:00.000Z'),
 
-  /**
-   * @param date
-   * @returns date가 속해있는 주의 일요일을 반환합니다.
-   */
-  startOfWeek: (date: Date): Date => getStartOfWeek(date),
+  addMs: (date: Date, ms: number): Date => new Date(date.getTime() + ms),
 
-  /**
-   * @param date
-   * @returns date 기준 일주일 전의 일요일을 반환합니다.
-   */
-  startOfLastWeek: (date: Date): Date =>
-    getStartOfWeek(new Date(date.getTime() - WEEK)),
+  moveWeek: (date: Date, count: number): Date => {
+    return new Date(date.getTime() + count * WEEK);
+  },
 
-  /**
-   * @param date
-   * @returns date가 속해있는 달의 1일을 반환합니다.
-   */
-  startOfMonth: (date: Date): Date => getStartOfMonth(date),
-
-  /**
-   * @param date
-   * @returns date 기준 한달 전의 1일을 반환합니다.
-   */
-  startOfLastMonth: (date: Date): Date => {
+  moveMonth: (date: Date, count: number): Date => {
     const copy = new Date(date);
-    copy.setMonth(copy.getMonth() - 1);
+    copy.setMonth(copy.getMonth() + count);
 
-    return getStartOfMonth(copy);
+    return copy;
+  },
+
+  /**
+   * @param date
+   * @returns date가 속한 날의 00시 00분 00초 를 반환합니다.
+   */
+  startOfDay: (date: Date): Date => {
+    const copy = new Date(date);
+    copy.setHours(0, 0, 0, 0);
+
+    return copy;
+  },
+
+  /**
+   * @param date
+   * @returns date가 속한 주의 일요일을 반환합니다.
+   */
+  startOfWeek: (date: Date): Date => {
+    return Time.startOfDay(new Date(date.getTime() - date.getDay() * DAY));
+  },
+
+  startOfMonth: (date: Date): Date => {
+    const copy = new Date(date);
+    copy.setDate(1);
+
+    return Time.startOfDay(copy);
+  },
+
+  startOfYear: (date: Date): Date => {
+    const copy = new Date(date);
+    copy.setMonth(0, 1);
+    copy.setHours(0, 0, 0, 0);
+
+    return copy;
   },
 } as const;


### PR DESCRIPTION
time 관련 로직들을 좀 더 확장성 있게 수정했고, 관련 로직들 점검 했습니다.
db 에 쿼리 보낼 땐 신경쓰지 않고 할 수 있는 상황입니다.
단, db aggregation 내부에선 Timezone 을 신경써야 하는 경우가 있을 수 있습니다. (ex. dateToString)

- close #46