### PR TITLE
feat: ✨  data date

### DIFF
--- a/app/src/app.module.ts
+++ b/app/src/app.module.ts
@@ -14,7 +14,7 @@ import { TotalModule } from './total/total.module';
 @Module({
   imports: [
     MongooseModule.forRoot(
-      `mongodb://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${process.env.TEMP_DB_URL}:27017/42stat`,
+      `mongodb://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${process.env.TEMP_DB_HOST}:${process.env.TEMP_DB_PORT}/42stat`,
     ),
     // MongooseModule.forRoot(
     //   `mongodb://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${process.env.DB_ENDPOINT}/${process.env.DB_NAME}`,

--- a/app/src/common/models/common.number.dateRanaged.ts
+++ b/app/src/common/models/common.number.dateRanaged.ts
@@ -1,0 +1,5 @@
+import { ObjectType } from '@nestjs/graphql';
+import { DateRanged } from 'src/dateRange/models/dateRange.model';
+
+@ObjectType()
+export class NumberDateRanged extends DateRanged(Number) {}

--- a/app/src/common/models/common.user.model.ts
+++ b/app/src/common/models/common.user.model.ts
@@ -1,4 +1,5 @@
 import { Field, Float, ObjectType, PickType } from '@nestjs/graphql';
+import { ArrayDateRanged } from 'src/dateRange/models/dateRange.model';
 import { UserProfile } from 'src/personalGeneral/models/personal.general.userProfile.model';
 
 @ObjectType()
@@ -16,3 +17,6 @@ export class UserRanking {
   @Field((_type) => Float)
   value: number;
 }
+
+@ObjectType()
+export class UserRankingDateRanged extends ArrayDateRanged(UserRanking) {}

--- a/app/src/dateRange/dateRange.service.ts
+++ b/app/src/dateRange/dateRange.service.ts
@@ -1,0 +1,13 @@
+import { IDateRangedType } from './models/dateRange.model';
+
+export const generateDateRanged = <T>(
+  data: T,
+  from: Date,
+  to: Date,
+): IDateRangedType<T> => {
+  return {
+    data,
+    from,
+    to,
+  } as const;
+};

--- a/app/src/dateRange/models/dateRange.model.ts
+++ b/app/src/dateRange/models/dateRange.model.ts
@@ -1,0 +1,48 @@
+import { Type } from '@nestjs/common';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+export interface IDateRangedType<T> {
+  data: T;
+  from: Date;
+  to: Date;
+}
+
+export function DateRanged<T>(classRef: Type<T>): Type<IDateRangedType<T>> {
+  @ObjectType({ isAbstract: true })
+  abstract class DateRangedType implements IDateRangedType<T> {
+    @Field((_type) => classRef)
+    data: T;
+
+    @Field()
+    from: Date;
+
+    @Field()
+    to: Date;
+  }
+
+  return DateRangedType as Type<IDateRangedType<T>>;
+}
+
+export interface IArrayDateRangedType<T> {
+  data: T[];
+  from: Date;
+  to: Date;
+}
+
+export function ArrayDateRanged<T>(
+  classRef: Type<T>,
+): Type<IArrayDateRangedType<T>> {
+  @ObjectType({ isAbstract: true })
+  abstract class DateRangedType implements IArrayDateRangedType<T> {
+    @Field((_type) => [classRef])
+    data: T[];
+
+    @Field()
+    from: Date;
+
+    @Field()
+    to: Date;
+  }
+
+  return DateRangedType as Type<IArrayDateRangedType<T>>;
+}

--- a/app/src/home/home.resolver.ts
+++ b/app/src/home/home.resolver.ts
@@ -1,5 +1,9 @@
 import { Query, ResolveField, Resolver } from '@nestjs/graphql';
-import { UserRanking } from 'src/common/models/common.user.model';
+import { NumberDateRanged } from 'src/common/models/common.number.dateRanaged';
+import {
+  UserRanking,
+  UserRankingDateRanged,
+} from 'src/common/models/common.user.model';
 import { HomeService } from './home.service';
 import { Home } from './models/home.model';
 
@@ -10,8 +14,8 @@ export class HomeResolver {
   @Query((_returns) => Home)
   async getHomePage() {
     return {
-      lastMonthBlackholedCnt: 30,
-      currMonthBlackholedCnt: 31,
+      lastMonthBlackholedCnt: { data: 30, from: new Date(), to: new Date() },
+      currMonthBlackholedCnt: { data: 31, from: new Date(), to: new Date() },
       currRegisteredCntRank: [
         {
           projectPreview: {
@@ -161,23 +165,27 @@ export class HomeResolver {
           value: 13.76,
         },
       ],
-      lastExamResult: [
-        { rank: 2, passCnt: 9, totalCnt: 20 },
-        { rank: 3, passCnt: 3, totalCnt: 20 },
-        { rank: 4, passCnt: 4, totalCnt: 12 },
-        { rank: 5, passCnt: 8, totalCnt: 18 },
-        { rank: 6, passCnt: 1, totalCnt: 10 },
-      ],
+      lastExamResult: {
+        data: [
+          { rank: 2, passCnt: 9, totalCnt: 20 },
+          { rank: 3, passCnt: 3, totalCnt: 20 },
+          { rank: 4, passCnt: 4, totalCnt: 12 },
+          { rank: 5, passCnt: 8, totalCnt: 18 },
+          { rank: 6, passCnt: 1, totalCnt: 10 },
+        ],
+        from: new Date(),
+        to: new Date(),
+      },
     };
   }
 
-  @ResolveField('currWeekEvalCnt', (_returns) => Number)
-  async currWeekEvalCnt(): Promise<number> {
+  @ResolveField('currWeekEvalCnt', (_returns) => NumberDateRanged)
+  async currWeekEvalCnt(): Promise<NumberDateRanged> {
     return await this.homeService.currWeekEvalCnt();
   }
 
-  @ResolveField('lastWeekEvalCnt', (_returns) => Number)
-  async lastWeekEvalCnt(): Promise<number> {
+  @ResolveField('lastWeekEvalCnt', (_returns) => NumberDateRanged)
+  async lastWeekEvalCnt(): Promise<NumberDateRanged> {
     return await this.homeService.lastWeekEvalCnt();
   }
 
@@ -186,8 +194,8 @@ export class HomeResolver {
     return await this.homeService.totalEvalCntRank();
   }
 
-  @ResolveField('monthlyEvalCntRank', (_returns) => [UserRanking])
-  async monthlyEvalCntRank(): Promise<UserRanking[]> {
+  @ResolveField('monthlyEvalCntRank', (_returns) => UserRankingDateRanged)
+  async monthlyEvalCntRank(): Promise<UserRankingDateRanged> {
     return await this.homeService.monthlyEvalCntRank();
   }
 }

--- a/app/src/home/home.service.ts
+++ b/app/src/home/home.service.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { UserRanking } from 'src/common/models/common.user.model';
+import { NumberDateRanged } from 'src/common/models/common.number.dateRanaged';
+import {
+  UserRanking,
+  UserRankingDateRanged,
+} from 'src/common/models/common.user.model';
+import { generateDateRanged } from 'src/dateRange/dateRange.service';
 import { ScaleTeamsService } from 'src/scaleTeams/scaleTeams.service';
 import { Time } from 'src/util';
 
@@ -7,40 +12,50 @@ import { Time } from 'src/util';
 export class HomeService {
   constructor(private scaleTeamService: ScaleTeamsService) {}
 
-  async currWeekEvalCnt(): Promise<number> {
+  async currWeekEvalCnt(): Promise<NumberDateRanged> {
     const currDate = Time.curr();
     const currWeek = Time.startOfWeek(currDate);
     const nextWeek = Time.moveWeek(currWeek, 1);
 
-    return await this.scaleTeamService.getEvalCount({
+    const evalCount = await this.scaleTeamService.getEvalCount({
       beginAt: { $gte: currWeek, $lt: nextWeek },
       filledAt: { $ne: null },
     });
+
+    return generateDateRanged(evalCount, currWeek, Time.moveDate(nextWeek, -1));
   }
 
-  async lastWeekEvalCnt(): Promise<number> {
+  async lastWeekEvalCnt(): Promise<NumberDateRanged> {
     const currDate = Time.curr();
     const currWeek = Time.startOfWeek(currDate);
     const lastWeek = Time.moveWeek(currWeek, -1);
 
-    return await this.scaleTeamService.getEvalCount({
+    const evalCount = await this.scaleTeamService.getEvalCount({
       beginAt: { $gte: lastWeek, $lt: currWeek },
       filledAt: { $ne: null },
     });
+
+    return generateDateRanged(evalCount, lastWeek, Time.moveDate(currWeek, -1));
   }
 
   async totalEvalCntRank(): Promise<UserRanking[]> {
     return this.scaleTeamService.getEvalCountRank();
   }
 
-  async monthlyEvalCntRank(): Promise<UserRanking[]> {
+  async monthlyEvalCntRank(): Promise<UserRankingDateRanged> {
     const currDate = Time.curr();
     const currMonth = Time.startOfMonth(currDate);
     const nextMonth = Time.moveMonth(currMonth, 1);
 
-    return this.scaleTeamService.getEvalCountRank({
+    const evalCountRank = await this.scaleTeamService.getEvalCountRank({
       beginAt: { $gte: currMonth, $lt: nextMonth },
       filledAt: { $ne: null },
     });
+
+    return generateDateRanged(
+      evalCountRank,
+      currMonth,
+      Time.moveDate(nextMonth, -1),
+    );
   }
 }

--- a/app/src/home/models/home.model.ts
+++ b/app/src/home/models/home.model.ts
@@ -1,6 +1,8 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import { ProjectRanking } from 'src/project/models/project.ranking.model';
+import { NumberDateRanged } from 'src/common/models/common.number.dateRanaged';
 import { UserRanking } from 'src/common/models/common.user.model';
+import { ArrayDateRanged } from 'src/dateRange/models/dateRange.model';
+import { ProjectRanking } from 'src/project/models/project.ranking.model';
 
 @ObjectType()
 export class ExamResult {
@@ -15,18 +17,15 @@ export class ExamResult {
 }
 
 @ObjectType()
+export class ExamResultDateRanged extends ArrayDateRanged(ExamResult) {}
+
+@ObjectType()
 export class Home {
   @Field()
-  currWeekEvalCnt: number;
+  currMonthBlackholedCnt: NumberDateRanged;
 
   @Field()
-  lastWeekEvalCnt: number;
-
-  @Field()
-  currMonthBlackholedCnt: number;
-
-  @Field()
-  lastMonthBlackholedCnt: number; //todo: 기획에는 없지만 만들어둠
+  lastMonthBlackholedCnt: NumberDateRanged; //todo: 기획에는 없지만 만들어둠 // 이거 비교하려면 필요한게 맞지 않나?
 
   @Field((_type) => [ProjectRanking])
   currRegisteredCntRank: ProjectRanking[];
@@ -43,6 +42,6 @@ export class Home {
   @Field((_type) => [UserRanking])
   levelRank: UserRanking[];
 
-  @Field((_type) => [ExamResult])
-  lastExamResult: ExamResult[];
+  @Field()
+  lastExamResult: ExamResultDateRanged;
 }

--- a/app/src/personalEval/models/personal.eval.model.ts
+++ b/app/src/personalEval/models/personal.eval.model.ts
@@ -1,4 +1,5 @@
 import { Field, Float, ObjectType } from '@nestjs/graphql';
+import { NumberDateRanged } from 'src/common/models/common.number.dateRanaged';
 
 // export enum EvalUserDifficulty {
 //   EASY,
@@ -20,10 +21,10 @@ import { Field, Float, ObjectType } from '@nestjs/graphql';
 @ObjectType()
 export class PersonalEval {
   @Field()
-  currMonthCount: number;
+  currMonthCount: NumberDateRanged;
 
   @Field()
-  lastMonthCount: number;
+  lastMonthCount: NumberDateRanged;
 
   @Field()
   totalCount: number;

--- a/app/src/personalEval/personal.eval.resolver.ts
+++ b/app/src/personalEval/personal.eval.resolver.ts
@@ -13,7 +13,7 @@ export class PersonalEvalResolver {
 
   // todo: 이 페이지 이름 바꿉시다
   @Query((_returns) => PersonalEval)
-  async getPersonalEvalPage(@Args('uid') uid: number): Promise<object> {
+  async getPersonalEvalPage(@Args('uid') uid: number): Promise<PersonalEval> {
     return {
       currMonthCount: await this.personalEvalService.currMonthCount(uid),
       lastMonthCount: await this.personalEvalService.lastMonthCount(uid),

--- a/app/src/personalEval/personal.eval.service.ts
+++ b/app/src/personalEval/personal.eval.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { NumberDateRanged } from 'src/common/models/common.number.dateRanaged';
+import { generateDateRanged } from 'src/dateRange/dateRange.service';
 import { ScaleTeamsService } from 'src/scaleTeams/scaleTeams.service';
 import { Time } from 'src/util';
 
@@ -6,27 +8,39 @@ import { Time } from 'src/util';
 export class PersonalEvalService {
   constructor(private scaleTeamService: ScaleTeamsService) {}
 
-  async currMonthCount(uid: number): Promise<number> {
+  async currMonthCount(uid: number): Promise<NumberDateRanged> {
     const currDate = Time.curr();
     const currMonth = Time.startOfMonth(currDate);
 
-    return await this.scaleTeamService.getEvalCount({
+    const evalCount = await this.scaleTeamService.getEvalCount({
       'corrector.id': uid,
       beginAt: { $gte: currMonth },
       filledAt: { $ne: null },
     });
+
+    return generateDateRanged(
+      evalCount,
+      currMonth,
+      Time.moveDate(Time.moveMonth(currMonth, 1), -1),
+    );
   }
 
-  async lastMonthCount(uid: number): Promise<number> {
+  async lastMonthCount(uid: number): Promise<NumberDateRanged> {
     const currDate = Time.curr();
     const currMonth = Time.startOfMonth(currDate);
     const lastMonth = Time.moveMonth(currMonth, -1);
 
-    return await this.scaleTeamService.getEvalCount({
+    const evalCount = await this.scaleTeamService.getEvalCount({
       'corrector.id': uid,
       beginAt: { $gte: lastMonth, $lt: currMonth },
       filledAt: { $ne: null },
     });
+
+    return generateDateRanged(
+      evalCount,
+      lastMonth,
+      Time.moveDate(currMonth, -1),
+    );
   }
 
   async totalCount(uid: number): Promise<number> {

--- a/app/src/personalGeneral/models/personal.general.model.ts
+++ b/app/src/personalGeneral/models/personal.general.model.ts
@@ -1,4 +1,8 @@
 import { Field, Float, ID, Int, ObjectType } from '@nestjs/graphql';
+import {
+  ArrayDateRanged,
+  DateRanged,
+} from 'src/dateRange/models/dateRange.model';
 
 // todo: erase this
 @ObjectType()
@@ -59,6 +63,9 @@ export class LogtimeInfo {
 }
 
 @ObjectType()
+export class LogtimeInfoDateRanged extends DateRanged(LogtimeInfo) {}
+
+@ObjectType()
 export class TeamInfo {
   @Field((_type) => String, { nullable: true })
   lastRegistered: string | null;
@@ -81,6 +88,9 @@ export class LevelGraph {
   @Field((_type) => Float)
   averageLevel: number;
 }
+
+@ObjectType()
+export class LevelGraphDateRanged extends ArrayDateRanged(LevelGraph) {}
 
 @ObjectType()
 // eslint-disable-next-line

--- a/app/src/personalGeneral/personal.general.resolver.ts
+++ b/app/src/personalGeneral/personal.general.resolver.ts
@@ -1,7 +1,7 @@
 import { Query, ResolveField, Resolver } from '@nestjs/graphql';
 import {
-  LevelGraph,
-  LogtimeInfo,
+  LevelGraphDateRanged,
+  LogtimeInfoDateRanged,
   PersonalGeneral,
   TeamInfo,
 } from './models/personal.general.model';
@@ -17,8 +17,8 @@ export class PersonalGeneralResolver {
     return {};
   }
 
-  @ResolveField('logtimeInfo', (_returns) => LogtimeInfo)
-  async getLogtimeInfo() {
+  @ResolveField('logtimeInfo', (_returns) => LogtimeInfoDateRanged)
+  async getLogtimeInfo(): Promise<LogtimeInfoDateRanged> {
     return await this.personalGeneralService.getLogtimeInfoByUid(99947);
   }
 
@@ -27,8 +27,8 @@ export class PersonalGeneralResolver {
     return await this.personalGeneralService.getTeamInfoByUid(99947);
   }
 
-  @ResolveField('levelGraphs', (_returns) => [LevelGraph])
-  async getLevelHistory() {
+  @ResolveField('levelGraphs', (_returns) => LevelGraphDateRanged)
+  async getLevelHistory(): Promise<LevelGraphDateRanged> {
     return await this.personalGeneralService.getLevelHistroyByUid(99947);
   }
 

--- a/app/src/personalGeneral/personal.general.service.ts
+++ b/app/src/personalGeneral/personal.general.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import * as fs from 'fs/promises';
+import { generateDateRanged } from 'src/dateRange/dateRange.service';
+import { Time } from 'src/util';
+import {
+  LevelGraphDateRanged,
+  LogtimeInfoDateRanged,
+} from './models/personal.general.model';
 import { UserGrade } from './models/personal.general.userProfile.model';
 
 @Injectable()
@@ -13,7 +19,7 @@ export class PersonalGeneralService {
     return ret;
   }
 
-  async getLogtimeInfoByUid(uid: number) {
+  async getLogtimeInfoByUid(uid: number): Promise<LogtimeInfoDateRanged> {
     const locations = await this.readTempLocation();
 
     const monthStart = new Date(
@@ -35,7 +41,7 @@ export class PersonalGeneralService {
         new Date(curr.end_at).getTime(),
     );
 
-    return {
+    const logtimeInfo = {
       currMonthLogtime: Math.floor(
         currMonth.reduce((acc: number, curr: any) => {
           return (
@@ -66,8 +72,14 @@ export class PersonalGeneralService {
         evening: 123,
         night: 123,
       },
-      preferredCluster: 1,
+      preferredCluster: 'c1',
     };
+
+    return generateDateRanged(
+      logtimeInfo,
+      lastMonthStart,
+      Time.moveDate(monthStart, -1),
+    );
   }
 
   async getTeamInfoByUid(uid: number) {
@@ -88,8 +100,8 @@ export class PersonalGeneralService {
     };
   }
 
-  async getLevelHistroyByUid(uid: number) {
-    return [
+  async getLevelHistroyByUid(uid: number): Promise<LevelGraphDateRanged> {
+    const levelGraph = [
       {
         date: new Date('2022-01-01'),
         userLevel: 2,
@@ -151,6 +163,8 @@ export class PersonalGeneralService {
         averageLevel: 3,
       },
     ];
+
+    return generateDateRanged(levelGraph, new Date('2022'), new Date('2023'));
   }
 
   async getUserInfo(uid: number) {

--- a/app/src/schema.gql
+++ b/app/src/schema.gql
@@ -64,6 +64,12 @@ type UserRanking {
   value: Float!
 }
 
+type UserRankingDateRanged {
+  data: [UserRanking!]!
+  from: DateTime!
+  to: DateTime!
+}
+
 type ProjectPreview {
   id: ID!
   name: String!
@@ -112,6 +118,12 @@ type EvalLogsPaginated {
   pageNumber: Int!
 }
 
+type NumberDateRanged {
+  data: Int!
+  from: DateTime!
+  to: DateTime!
+}
+
 type ProjectRanking {
   projectPreview: ProjectPreview!
   value: Int!
@@ -123,18 +135,24 @@ type ExamResult {
   totalCnt: Int!
 }
 
+type ExamResultDateRanged {
+  data: [ExamResult!]!
+  from: DateTime!
+  to: DateTime!
+}
+
 type Home {
-  currWeekEvalCnt: Int!
-  lastWeekEvalCnt: Int!
-  currMonthBlackholedCnt: Int!
-  lastMonthBlackholedCnt: Int!
+  currMonthBlackholedCnt: NumberDateRanged!
+  lastMonthBlackholedCnt: NumberDateRanged!
   currRegisteredCntRank: [ProjectRanking!]!
   monthlyExpIncrementRank: [UserRanking!]!
   monthlyAccessTimeRank: [UserRanking!]!
   totalEvalCntRank: [UserRanking!]!
   levelRank: [UserRanking!]!
-  lastExamResult: [ExamResult!]!
-  monthlyEvalCntRank: [UserRanking!]!
+  lastExamResult: ExamResultDateRanged!
+  currWeekEvalCnt: NumberDateRanged!
+  lastWeekEvalCnt: NumberDateRanged!
+  monthlyEvalCntRank: UserRankingDateRanged!
 }
 
 type TempTeam {
@@ -170,6 +188,12 @@ type LogtimeInfo {
   preferredCluster: String!
 }
 
+type LogtimeInfoDateRanged {
+  data: LogtimeInfo!
+  from: DateTime!
+  to: DateTime!
+}
+
 type TeamInfo {
   lastRegistered: String
   lastPass: String
@@ -182,16 +206,22 @@ type LevelGraph {
   averageLevel: Float!
 }
 
+type LevelGraphDateRanged {
+  data: [LevelGraph!]!
+  from: DateTime!
+  to: DateTime!
+}
+
 type PersonalGeneral {
-  logtimeInfo: LogtimeInfo!
+  logtimeInfo: LogtimeInfoDateRanged!
   teamInfo: TeamInfo!
-  levelGraphs: [LevelGraph!]!
+  levelGraphs: LevelGraphDateRanged!
   userProfile: UserProfile!
 }
 
 type PersonalEval {
-  currMonthCount: Int!
-  lastMonthCount: Int!
+  currMonthCount: NumberDateRanged!
+  lastMonthCount: NumberDateRanged!
   totalCount: Int!
   averageDuration: Int!
 
@@ -255,7 +285,7 @@ type Total {
   projectInfo(projectName: String! = "libft"): ProjectInfo!
   totalScores: [TotalScore!]!
   scoreRecords: [ScoreRecords!]!
-  monthlyScoreRanks: [UserRanking!]!
+  monthlyScoreRanks: UserRankingDateRanged!
   totalEvalCount: Int!
   averageFeedbackLength: Int!
   averageCommentLength: Int!

--- a/app/src/total/total.resolver.ts
+++ b/app/src/total/total.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Int, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import { UserRanking } from 'src/common/models/common.user.model';
+import { UserRankingDateRanged } from 'src/common/models/common.user.model';
 import {
   ProjectInfo,
   ScoreRecords,
@@ -245,8 +245,8 @@ export class TotalResolver {
     return this.totalService.scoreRecords();
   }
 
-  @ResolveField('monthlyScoreRanks', (_returns) => [UserRanking])
-  async monthlyScoreRanks(): Promise<UserRanking[]> {
+  @ResolveField('monthlyScoreRanks', (_returns) => UserRankingDateRanged)
+  async monthlyScoreRanks(): Promise<UserRankingDateRanged> {
     return await this.totalService.monthlyScoreRanks();
   }
 

--- a/app/src/total/total.service.ts
+++ b/app/src/total/total.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
+import { UserRankingDateRanged } from 'src/common/models/common.user.model';
+import { generateDateRanged } from 'src/dateRange/dateRange.service';
 import { ScaleTeamsService } from 'src/scaleTeams/scaleTeams.service';
 import { ScoreService } from 'src/score/score.service';
-import { ScoreRecords, TotalScore } from './models/total.model';
 import { Time } from 'src/util';
-import { UserRanking } from 'src/common/models/common.user.model';
+import { ScoreRecords, TotalScore } from './models/total.model';
 
 @Injectable()
 export class TotalService {
@@ -43,12 +44,22 @@ export class TotalService {
     }));
   }
 
-  async monthlyScoreRanks(): Promise<UserRanking[]> {
+  async monthlyScoreRanks(): Promise<UserRankingDateRanged> {
     const currDate = Time.curr();
     const currMonth = Time.startOfMonth(currDate);
     const nextMonth = Time.moveMonth(currMonth, 1);
 
-    return await this.scoreService.getScoreRanks(currMonth, nextMonth, 3);
+    const scoreRanks = await this.scoreService.getScoreRanks(
+      currMonth,
+      nextMonth,
+      3,
+    );
+
+    return generateDateRanged(
+      scoreRanks,
+      currMonth,
+      Time.moveDate(nextMonth, -1),
+    );
   }
 
   async totalEvalCount(): Promise<number> {

--- a/app/src/util/time.ts
+++ b/app/src/util/time.ts
@@ -19,7 +19,11 @@ export const Time = {
   // todo: 개발 용도. 완료 후 인자 제거 필요합니다.
   curr: (): Date => new Date('2023-04-10T00:00:00.000Z'),
 
-  addMs: (date: Date, ms: number): Date => new Date(date.getTime() + ms),
+  moveMs: (date: Date, ms: number): Date => new Date(date.getTime() + ms),
+
+  moveDate: (date: Date, count: number): Date => {
+    return new Date(date.getTime() + count * DAY);
+  },
 
   moveWeek: (date: Date, count: number): Date => {
     return new Date(date.getTime() + count * WEEK);


### PR DESCRIPTION
기존에 있던 pagination api 와 거의 동일한 구조로 만들었습니다.
차이점은, pagination 은 무조건 1차원 배열 형태로 데이터를 받기 때문에 한가지 타입으로 되었지만,
dateRange 에는 단일 데이터, 혹은 복수의 데이터 모두 들어올 수 있기 때문에, graphql 호환성을 위해 두가지 타입을 만들어야 했습니다.
다만, 이것은 사용할때 데이터가 배열인지 아닌지만 한번 판단하면, 그 외 모든 부분은 동일한 구조로 사용 가능합니다.

```ts
export interface IDateRangedType<T> {
  data: T;
  from: Date;
  to: Date;
}

export function DateRanged<T>(classRef: Type<T>): Type<IDateRangedType<T>> {
  @ObjectType({ isAbstract: true })
  abstract class DateRangedType implements IDateRangedType<T> {
    @Field((_type) => classRef)
    data: T;

    @Field()
    from: Date;

    @Field()
    to: Date;
  }

  return DateRangedType as Type<IDateRangedType<T>>;
}

export interface IArrayDateRangedType<T> {
  data: T[];
  from: Date;
  to: Date;
}

export function ArrayDateRanged<T>(
  classRef: Type<T>,
): Type<IArrayDateRangedType<T>> {
  @ObjectType({ isAbstract: true })
  abstract class DateRangedType implements IArrayDateRangedType<T> {
    @Field((_type) => [classRef])
    data: T[];

    @Field()
    from: Date;

    @Field()
    to: Date;
  }

  return DateRangedType as Type<IArrayDateRangedType<T>>;
}

export const generateDateRanged = <T>(
  data: T,
  from: Date,
  to: Date,
): IDateRangedType<T> => {
  return {
    data,
    from,
    to,
  } as const;
};
 
```
아래와 같이 사용합니다.

```ts
@ObjectType()
export class LogtimeInfo {
  @Field()
  currMonthLogtime: number;

  @Field()
  lastMonthLogtime: number;

  @Field()
  preferredTime: PreferredTime;

  @Field()
  preferredCluster: string;
}

@ObjectType()
export class LogtimeInfoDateRanged extends DateRanged(LogtimeInfo) {}

// service logic 에서 Logtime을 구한 뒤,
return generateDateRaanaed(logtimeInfo, fromDate, toDate)
```

기존 graphql api 보다 한 단계 더 깊어졌기 때문에, 프론트엔드에서 이를 호환시켜야 합니다.
@yoopark @lev-Zero 

- close #62 