### PR TITLE
refactor: :fire: byDateRange 삭제, 함수 이름에서 쿼리 이름과 중복되는 부분 제거

### DIFF
--- a/app/src/api/scaleTeam/scaleTeam.service.ts
+++ b/app/src/api/scaleTeam/scaleTeam.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import type { FilterQuery, Model } from 'mongoose';
 import type { AggrNumeric } from 'src/common/db/common.db.aggregation';

--- a/app/src/page/leaderboard/eval/leaderboard.eval.module.ts
+++ b/app/src/page/leaderboard/eval/leaderboard.eval.module.ts
@@ -1,18 +1,21 @@
 import { Module } from '@nestjs/common';
 import { ScaleTeamModule } from 'src/api/scaleTeam/scaleTeam.module';
 import { ScaleTeamService } from 'src/api/scaleTeam/scaleTeam.service';
+import { DateRangeModule } from 'src/dateRange/dateRange.module';
+import { DateRangeService } from 'src/dateRange/dateRange.service';
 import { LeaderboardUtilModule } from '../util/leaderboard.util.module';
 import { LeaderboardUtilService } from '../util/leaderboard.util.service';
 import { LeaderboardEvalResolver } from './leaderboard.eval.resolver';
 import { LeaderboardEvalService } from './leaderboard.eval.service';
 
 @Module({
-  imports: [LeaderboardUtilModule, ScaleTeamModule],
+  imports: [LeaderboardUtilModule, ScaleTeamModule, DateRangeModule],
   providers: [
     LeaderboardEvalResolver,
     LeaderboardEvalService,
     LeaderboardUtilService,
     ScaleTeamService,
+    DateRangeService,
   ],
 })
 // eslint-disable-next-line

--- a/app/src/page/leaderboard/eval/leaderboard.eval.resolver.ts
+++ b/app/src/page/leaderboard/eval/leaderboard.eval.resolver.ts
@@ -1,8 +1,5 @@
 import { Args, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import {
-  DateRangeArgs,
-  DateTemplateArgs,
-} from 'src/dateRange/dtos/dateRange.dto';
+import { DateTemplateArgs } from 'src/dateRange/dtos/dateRange.dto';
 import {
   LeaderboardElement,
   LeaderboardElementDateRanged,
@@ -21,24 +18,14 @@ export class LeaderboardEvalResolver {
 
   @ResolveField('total', (_returns) => LeaderboardElement)
   async total(): Promise<LeaderboardElement> {
-    return await this.leaderboardEvalService.evalCountRank(99947);
-  }
-
-  @ResolveField('byDateRange', (_returns) => LeaderboardElementDateRanged)
-  async byDateRange(
-    @Args() dateRange: DateRangeArgs,
-  ): Promise<LeaderboardElementDateRanged> {
-    return await this.leaderboardEvalService.evalCountRankByDateRange(
-      99947,
-      dateRange,
-    );
+    return await this.leaderboardEvalService.rank(99947);
   }
 
   @ResolveField('byDateTemplate', (_returns) => LeaderboardElementDateRanged)
   async byDateTemplate(
     @Args() { dateTemplate }: DateTemplateArgs,
   ): Promise<LeaderboardElementDateRanged> {
-    return await this.leaderboardEvalService.evalCountRankByDateTemplate(
+    return await this.leaderboardEvalService.rankByDateTemplate(
       99947,
       dateTemplate,
     );

--- a/app/src/page/leaderboard/eval/models/leaderboard.eval.model.ts
+++ b/app/src/page/leaderboard/eval/models/leaderboard.eval.model.ts
@@ -10,8 +10,5 @@ export class LeaderboardEval {
   total: LeaderboardElement;
 
   @Field()
-  byDateRange: LeaderboardElementDateRanged;
-
-  @Field()
   byDateTemplate: LeaderboardElementDateRanged;
 }

--- a/app/src/page/leaderboard/exp/leaderboard.exp.module.ts
+++ b/app/src/page/leaderboard/exp/leaderboard.exp.module.ts
@@ -1,15 +1,18 @@
 import { Module } from '@nestjs/common';
+import { DateRangeModule } from 'src/dateRange/dateRange.module';
+import { DateRangeService } from 'src/dateRange/dateRange.service';
 import { LeaderboardUtilModule } from '../util/leaderboard.util.module';
 import { LeaderboardUtilService } from '../util/leaderboard.util.service';
 import { LeaderboardExpResolver } from './leaderboard.exp.resolver';
 import { LeaderboardExpService } from './leaderboard.exp.service';
 
 @Module({
-  imports: [LeaderboardUtilModule],
+  imports: [LeaderboardUtilModule, DateRangeModule],
   providers: [
     LeaderboardExpResolver,
     LeaderboardExpService,
     LeaderboardUtilService,
+    DateRangeService,
   ],
 })
 // eslint-disable-next-line

--- a/app/src/page/leaderboard/exp/leaderboard.exp.resolver.ts
+++ b/app/src/page/leaderboard/exp/leaderboard.exp.resolver.ts
@@ -1,8 +1,5 @@
-import { Args, Int, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import {
-  DateRangeArgs,
-  DateTemplateArgs,
-} from 'src/dateRange/dtos/dateRange.dto';
+import { Args, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import { DateTemplateArgs } from 'src/dateRange/dtos/dateRange.dto';
 import { LeaderboardElementDateRanged } from '../models/leaderboard.model';
 import { LeaderboardExpService } from './leaderboard.exp.service';
 import { LeaderboardExp } from './models/leaderboard.exp.model';
@@ -16,21 +13,11 @@ export class LeaderboardExpResolver {
     return {};
   }
 
-  @ResolveField('byDateRange', (_returns) => Int)
-  async byDateRange(
-    @Args() dateRange: DateRangeArgs,
-  ): Promise<LeaderboardElementDateRanged> {
-    return await this.leaderboardExpService.expIncrementRankByDateRange(
-      99947,
-      dateRange,
-    );
-  }
-
   @ResolveField('byDateTemplate', (_returns) => LeaderboardElementDateRanged)
   async byDateTemplate(
     @Args() { dateTemplate }: DateTemplateArgs,
   ): Promise<LeaderboardElementDateRanged> {
-    return await this.leaderboardExpService.expIncrementRankByDateTemplate(
+    return await this.leaderboardExpService.rankByDateTemplate(
       99947,
       dateTemplate,
     );

--- a/app/src/page/leaderboard/exp/models/leaderboard.exp.model.ts
+++ b/app/src/page/leaderboard/exp/models/leaderboard.exp.model.ts
@@ -4,8 +4,5 @@ import { LeaderboardElementDateRanged } from '../../models/leaderboard.model';
 @ObjectType()
 export class LeaderboardExp {
   @Field()
-  byDateRange: LeaderboardElementDateRanged;
-
-  @Field()
   byDateTemplate: LeaderboardElementDateRanged;
 }

--- a/app/src/page/leaderboard/level/leaderboard.level.resovler.ts
+++ b/app/src/page/leaderboard/level/leaderboard.level.resovler.ts
@@ -14,6 +14,6 @@ export class LeaderboardLevelResolver {
 
   @ResolveField('total', (_returns) => LeaderboardElement)
   async total(): Promise<LeaderboardElement> {
-    return await this.leaderboardLevelService.levelRank(99947, 50);
+    return await this.leaderboardLevelService.rank(99947, 50);
   }
 }

--- a/app/src/page/leaderboard/level/leaderboard.level.service.ts
+++ b/app/src/page/leaderboard/level/leaderboard.level.service.ts
@@ -9,7 +9,7 @@ export class LeaderboardLevelService {
     private leaderboardUtilService: LeaderboardUtilService,
   ) {}
 
-  async levelRank(userId: number, limit: number) {
+  async rank(userId: number, limit: number) {
     const userRanking = await this.cursusUserService.rank('level', limit);
 
     return this.leaderboardUtilService.userRankingToLeaderboardElement(

--- a/app/src/page/leaderboard/score/leaderboard.score.module.ts
+++ b/app/src/page/leaderboard/score/leaderboard.score.module.ts
@@ -3,13 +3,16 @@ import { LeaderboardUtilModule } from '../util/leaderboard.util.module';
 import { LeaderboardUtilService } from '../util/leaderboard.util.service';
 import { LeaderboardScoreResolver } from './leaderboard.score.resolver';
 import { LeaderboardScoreService } from './leaderboard.score.service';
+import { DateRangeModule } from 'src/dateRange/dateRange.module';
+import { DateRangeService } from 'src/dateRange/dateRange.service';
 
 @Module({
-  imports: [LeaderboardUtilModule],
+  imports: [LeaderboardUtilModule, DateRangeModule],
   providers: [
     LeaderboardScoreResolver,
     LeaderboardScoreService,
     LeaderboardUtilService,
+    DateRangeService,
   ],
 })
 // eslint-disable-next-line

--- a/app/src/page/leaderboard/score/leaderboard.score.resolver.ts
+++ b/app/src/page/leaderboard/score/leaderboard.score.resolver.ts
@@ -1,8 +1,5 @@
 import { Args, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import {
-  DateRangeArgs,
-  DateTemplateArgs,
-} from 'src/dateRange/dtos/dateRange.dto';
+import { DateTemplateArgs } from 'src/dateRange/dtos/dateRange.dto';
 import {
   LeaderboardElement,
   LeaderboardElementDateRanged,
@@ -21,22 +18,12 @@ export class LeaderboardScoreResolver {
 
   @ResolveField('total', (_returns) => LeaderboardElement)
   async total(): Promise<LeaderboardElement> {
-    return await this.leaderboardScoreService.scoreRank(99947);
-  }
-
-  @ResolveField('byDateRange', (_returns) => LeaderboardElementDateRanged)
-  async byDateRange(
-    @Args() dateRangeArgs: DateRangeArgs,
-  ): Promise<LeaderboardElementDateRanged> {
-    return await this.leaderboardScoreService.scoreRankByDateRange(
-      99947,
-      dateRangeArgs,
-    );
+    return await this.leaderboardScoreService.rank(99947);
   }
 
   @ResolveField('byDateTemplate', (_returns) => LeaderboardElementDateRanged)
   async byDateTemplate(@Args() { dateTemplate }: DateTemplateArgs) {
-    return await this.leaderboardScoreService.scoreRankByDateTemplate(
+    return await this.leaderboardScoreService.rankByDateTemplate(
       99947,
       dateTemplate,
     );

--- a/app/src/page/leaderboard/score/models/leaderboard.score.model.ts
+++ b/app/src/page/leaderboard/score/models/leaderboard.score.model.ts
@@ -10,8 +10,5 @@ export class LeaderboardScore {
   total: LeaderboardElement;
 
   @Field()
-  byDateRange: LeaderboardElementDateRanged;
-
-  @Field()
   byDateTemplate: LeaderboardElementDateRanged;
 }

--- a/app/src/page/personal/general/models/personal.general.model.ts
+++ b/app/src/page/personal/general/models/personal.general.model.ts
@@ -3,10 +3,7 @@ import {
   IntDateRanged,
   StringDateRanged,
 } from 'src/common/models/common.dateRanaged.model';
-import {
-  ArrayDateRanged,
-  DateRanged,
-} from 'src/dateRange/models/dateRange.model';
+import { DateRanged } from 'src/dateRange/models/dateRange.model';
 import {
   UserProfile,
   UserScoreRank,


### PR DESCRIPTION
- #114
- leader board 같은 경우 DateRange Module 이 이미 적용되어 있었기 때문에, 불필요하게 제공하던 byDateRanged resolver 를 삭제하는 것에 초점을 맞췄습니다.