### PR TITLE
fix 🐛  user cache refresh

### DIFF
--- a/app/src/api/cursusUser/cursusUser.cache.service.ts
+++ b/app/src/api/cursusUser/cursusUser.cache.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import {
-  CacheUtilService,
+  CacheUtilRankingService,
   type RankCache,
+} from 'src/cache/cache.util.ranking.service';
+import {
+  CacheUtilService,
   type UserFullProfileMap,
 } from 'src/cache/cache.util.service';
 import { DateTemplate } from 'src/dateRange/dtos/dateRange.dto';
@@ -22,7 +25,10 @@ export type UserFullProfileCache = Awaited<
 
 @Injectable()
 export class CursusUserCacheService {
-  constructor(private readonly cacheUtilService: CacheUtilService) {}
+  constructor(
+    private readonly cacheUtilService: CacheUtilService,
+    private readonly cacheUtilRankingService: CacheUtilRankingService,
+  ) {}
 
   async getUserFullProfile(
     userId: number,
@@ -38,7 +44,7 @@ export class CursusUserCacheService {
     keyBase: UserRankingKey,
     userId: number,
   ): Promise<RankCache | undefined> {
-    return await this.cacheUtilService.getRawRank({
+    return await this.cacheUtilRankingService.getRawRank({
       keyBase,
       userId,
       dateTemplate: DateTemplate.TOTAL,
@@ -48,7 +54,7 @@ export class CursusUserCacheService {
   async getUserRanking(
     keyBase: UserRankingKey,
   ): Promise<RankCache[] | undefined> {
-    return await this.cacheUtilService.getRawRanking({
+    return await this.cacheUtilRankingService.getRawRanking({
       keyBase,
       dateTemplate: DateTemplate.TOTAL,
     });

--- a/app/src/api/cursusUser/cursusUser.service.ts
+++ b/app/src/api/cursusUser/cursusUser.service.ts
@@ -12,6 +12,7 @@ import type {
   UserPreview,
   UserRank,
 } from 'src/common/models/common.user.model';
+import type { UserFullProfile } from 'src/common/userFullProfile';
 import type { DateRangeArgs } from 'src/dateRange/dtos/dateRange.dto';
 import type {
   IntPerCircle,
@@ -20,7 +21,6 @@ import type {
 import { DateWrapper } from 'src/statDate/StatDate';
 import { CoalitionService } from '../coalition/coalition.service';
 import { lookupCoalition } from '../coalition/db/coalition.database.aggregate';
-import type { Coalition } from '../coalition/models/coalition.model';
 import { lookupCoalitionsUser } from '../coalitionsUser/db/coalitionsUser.database.aggregate';
 import { lookupQuestsUser } from '../questsUser/db/questsUser.database.aggregate';
 import {
@@ -28,23 +28,13 @@ import {
   INNER_QUEST_IDS,
 } from '../questsUser/questsUser.service';
 import { lookupTitle } from '../title/db/title.database.aggregate';
-import type { title } from '../title/db/title.database.schema';
 import { lookupTitlesUser } from '../titlesUser/db/titlesUser.database.aggregate';
-import type { titles_user } from '../titlesUser/db/titlesUser.database.schema';
 import type { UserFullProfileAggr } from './db/cursusUser.database.aggregate';
 import {
   aliveUserFilter,
   blackholedUserFilterByDateRange,
 } from './db/cursusUser.database.query';
 import { cursus_user } from './db/cursusUser.database.schema';
-
-export type UserFullProfile = {
-  cursusUser: cursus_user;
-  coalition?: Coalition;
-  titlesUsers: (titles_user & {
-    titles: title;
-  })[];
-};
 
 @Injectable()
 export class CursusUserService {
@@ -339,15 +329,5 @@ export class CursusUserService {
       value: valueExtractor(rawRank),
       rank: index + 1,
     }));
-  }
-
-  extractUserPreviewFromFullProfile(
-    userFullProfile: UserFullProfile,
-  ): UserPreview {
-    return {
-      id: userFullProfile.cursusUser.user.id,
-      login: userFullProfile.cursusUser.user.login,
-      imgUrl: userFullProfile.cursusUser.user.image.link,
-    };
   }
 }

--- a/app/src/api/cursusUser/db/cursusUser.database.aggregate.ts
+++ b/app/src/api/cursusUser/db/cursusUser.database.aggregate.ts
@@ -1,6 +1,5 @@
 import type { coalition } from 'src/api/coalition/db/coalition.database.schema';
-import type { UserFullProfile } from '../cursusUser.service';
-// eslint-disable-next-line
+import type { UserFullProfile } from 'src/common/userFullProfile';
 
 export type UserFullProfileAggr = Omit<UserFullProfile, 'coalition'> & {
   coalition?: coalition;

--- a/app/src/api/experienceUser/experienceUser.cache.service.ts
+++ b/app/src/api/experienceUser/experienceUser.cache.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import {
-  CacheUtilService,
-  type CacheSupportedDateTemplate,
+  CacheUtilRankingService,
+  type RankingSupportedDateTemplate,
   type RankCache,
-} from 'src/cache/cache.util.service';
+} from 'src/cache/cache.util.ranking.service';
 import { DateTemplate } from 'src/dateRange/dtos/dateRange.dto';
 
 export type ExpIncreamentRankingCacheSupportedDateTemplate = Extract<
-  CacheSupportedDateTemplate,
+  RankingSupportedDateTemplate,
   DateTemplate.CURR_MONTH | DateTemplate.CURR_WEEK
 >;
 
@@ -15,13 +15,15 @@ export const EXP_INCREAMENT_RANKING = 'expIncRanking';
 
 @Injectable()
 export class ExperienceUserCacheService {
-  constructor(private readonly cacheUtilService: CacheUtilService) {}
+  constructor(
+    private readonly cacheUtilRankingService: CacheUtilRankingService,
+  ) {}
 
   async getExpIncreamentRank(
     dateTemplate: ExpIncreamentRankingCacheSupportedDateTemplate,
     userId: number,
   ): Promise<RankCache | undefined> {
-    return await this.cacheUtilService.getRank({
+    return await this.cacheUtilRankingService.getRank({
       keyBase: EXP_INCREAMENT_RANKING,
       dateTemplate,
       userId,
@@ -31,7 +33,7 @@ export class ExperienceUserCacheService {
   async getExpIncreamentRanking(
     dateTemplate: ExpIncreamentRankingCacheSupportedDateTemplate,
   ): Promise<RankCache[] | undefined> {
-    return await this.cacheUtilService.getRanking({
+    return await this.cacheUtilRankingService.getRanking({
       keyBase: EXP_INCREAMENT_RANKING,
       dateTemplate,
     });

--- a/app/src/api/location/location.cache.service.ts
+++ b/app/src/api/location/location.cache.service.ts
@@ -1,15 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import {
-  CacheUtilService,
-  type CacheSupportedDateTemplate,
+  CacheUtilRankingService,
+  type RankingSupportedDateTemplate,
   type GetRankArgs,
   type GetRankingArgs,
   type RankCache,
-} from 'src/cache/cache.util.service';
+} from 'src/cache/cache.util.ranking.service';
 import { DateTemplate } from 'src/dateRange/dtos/dateRange.dto';
 
 export type LogtimeRankingCacheSupportedDateTemplate = Extract<
-  CacheSupportedDateTemplate,
+  RankingSupportedDateTemplate,
   DateTemplate.TOTAL | DateTemplate.CURR_MONTH | DateTemplate.LAST_MONTH
 >;
 
@@ -17,7 +17,9 @@ export const LOGTIME_RANKING = 'logtimeRanking';
 
 @Injectable()
 export class LocationCacheService {
-  constructor(private readonly cacheUtilService: CacheUtilService) {}
+  constructor(
+    private readonly cacheUtilRankingService: CacheUtilRankingService,
+  ) {}
 
   async getLogtimeRank(
     dateTemplate: LogtimeRankingCacheSupportedDateTemplate,
@@ -30,10 +32,10 @@ export class LocationCacheService {
     };
 
     if (dateTemplate === DateTemplate.TOTAL) {
-      return await this.cacheUtilService.getRawRank(args);
+      return await this.cacheUtilRankingService.getRawRank(args);
     }
 
-    return await this.cacheUtilService.getRank(args);
+    return await this.cacheUtilRankingService.getRank(args);
   }
 
   async getLogtimeRanking(
@@ -45,9 +47,9 @@ export class LocationCacheService {
     };
 
     if (dateTemplate === DateTemplate.TOTAL) {
-      return await this.cacheUtilService.getRawRanking(args);
+      return await this.cacheUtilRankingService.getRawRanking(args);
     }
 
-    return await this.cacheUtilService.getRanking(args);
+    return await this.cacheUtilRankingService.getRanking(args);
   }
 }

--- a/app/src/api/scaleTeam/scaleTeam.cache.service.ts
+++ b/app/src/api/scaleTeam/scaleTeam.cache.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import {
-  CacheUtilService,
-  type CacheSupportedDateTemplate,
+  CacheUtilRankingService,
+  type RankingSupportedDateTemplate,
   type GetRankArgs,
   type GetRankingArgs,
   type RankCache,
-} from 'src/cache/cache.util.service';
+} from 'src/cache/cache.util.ranking.service';
+import { CacheUtilService } from 'src/cache/cache.util.service';
 import { DateTemplate } from 'src/dateRange/dtos/dateRange.dto';
 import { ScaleTeamService } from './scaleTeam.service';
 
@@ -14,7 +15,7 @@ export const AVERAGE_FEEDBACK_LENGTH = 'averageFeedbackLength';
 export const AVERAGE_COMMENT_LENGTH = 'averageCommentLength';
 
 export type EvalCountRankingSupportedDateTemplate = Extract<
-  CacheSupportedDateTemplate,
+  RankingSupportedDateTemplate,
   DateTemplate.TOTAL | DateTemplate.CURR_MONTH | DateTemplate.CURR_WEEK
 >;
 
@@ -28,7 +29,10 @@ type AverageReviewLengthCache = Awaited<
 
 @Injectable()
 export class ScaleTeamCacheService {
-  constructor(private readonly cacheUtilService: CacheUtilService) {}
+  constructor(
+    private readonly cacheUtilService: CacheUtilService,
+    private readonly cacheUtilRankingService: CacheUtilRankingService,
+  ) {}
 
   async getEvalCountRank(
     dateTemplate: EvalCountRankingSupportedDateTemplate,
@@ -41,10 +45,10 @@ export class ScaleTeamCacheService {
     };
 
     if (dateTemplate === DateTemplate.TOTAL) {
-      return await this.cacheUtilService.getRawRank(args);
+      return await this.cacheUtilRankingService.getRawRank(args);
     }
 
-    return await this.cacheUtilService.getRank(args);
+    return await this.cacheUtilRankingService.getRank(args);
   }
 
   async getEvalCountRanking(
@@ -56,10 +60,10 @@ export class ScaleTeamCacheService {
     };
 
     if (dateTemplate === DateTemplate.TOTAL) {
-      return await this.cacheUtilService.getRawRanking(args);
+      return await this.cacheUtilRankingService.getRawRanking(args);
     }
 
-    return await this.cacheUtilService.getRanking(args);
+    return await this.cacheUtilRankingService.getRanking(args);
   }
 
   async getAverageReviewLength(

--- a/app/src/api/score/score.cache.service.ts
+++ b/app/src/api/score/score.cache.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import {
-  CacheUtilService,
-  type CacheSupportedDateTemplate,
+  CacheUtilRankingService,
+  type RankingSupportedDateTemplate,
   type RankCache,
-} from 'src/cache/cache.util.service';
+} from 'src/cache/cache.util.ranking.service';
+import { CacheUtilService } from 'src/cache/cache.util.service';
 import { DateTemplate } from 'src/dateRange/dtos/dateRange.dto';
 import { ScoreService } from './score.service';
 
@@ -12,7 +13,7 @@ export const TOTAL_SCORES_BY_COALITION = 'totalScoresByCoalition';
 export const SCORE_RECORDS = 'scoreRecords';
 
 export type ScoreRankingSupportedDateTemplate = Extract<
-  CacheSupportedDateTemplate,
+  RankingSupportedDateTemplate,
   DateTemplate.TOTAL | DateTemplate.CURR_MONTH | DateTemplate.CURR_WEEK
 >;
 
@@ -20,13 +21,16 @@ export type ScoreRecordsKey = typeof SCORE_RECORDS;
 
 @Injectable()
 export class ScoreCacheService {
-  constructor(private readonly cacheUtilService: CacheUtilService) {}
+  constructor(
+    private readonly cacheUtilService: CacheUtilService,
+    private readonly cacheUtilRankingService: CacheUtilRankingService,
+  ) {}
 
   async getScoreRank(
     dateTemplate: ScoreRankingSupportedDateTemplate,
     userId: number,
   ): Promise<RankCache | undefined> {
-    return await this.cacheUtilService.getRank({
+    return await this.cacheUtilRankingService.getRank({
       keyBase: SCORE_RANKING,
       userId,
       dateTemplate,
@@ -36,7 +40,7 @@ export class ScoreCacheService {
   async getScoreRanking(
     dateTemplate: ScoreRankingSupportedDateTemplate,
   ): Promise<RankCache[] | undefined> {
-    return await this.cacheUtilService.getRanking({
+    return await this.cacheUtilRankingService.getRanking({
       keyBase: SCORE_RANKING,
       dateTemplate,
     });

--- a/app/src/cache/cache.util.module.ts
+++ b/app/src/cache/cache.util.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { DateRangeModule } from 'src/dateRange/dateRange.module';
+import { CacheUtilRankingService } from './cache.util.ranking.service';
 import { CacheUtilService } from './cache.util.service';
 
 @Module({
   imports: [DateRangeModule],
-  providers: [CacheUtilService],
-  exports: [CacheUtilService],
+  providers: [CacheUtilService, CacheUtilRankingService],
+  exports: [CacheUtilService, CacheUtilRankingService],
 })
 // eslint-disable-next-line
 export class CacheUtilModule {}

--- a/app/src/cache/cache.util.ranking.service.ts
+++ b/app/src/cache/cache.util.ranking.service.ts
@@ -1,0 +1,291 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable } from '@nestjs/common';
+import type { Cache } from 'cache-manager';
+import { assertExist } from 'src/common/assertExist';
+import type {
+  UserPreview,
+  UserRank,
+} from 'src/common/models/common.user.model';
+import {
+  toUserPreviewFromFullProfile,
+  type UserFullProfile,
+} from 'src/common/userFullProfile';
+import { DateRangeService } from 'src/dateRange/dateRange.service';
+import { DateTemplate, type DateRange } from 'src/dateRange/dtos/dateRange.dto';
+import { DateWrapper } from 'src/statDate/StatDate';
+import { CacheUtilService, type CacheWithDate } from './cache.util.service';
+
+export type RankingSupportedDateTemplate = Exclude<
+  DateTemplate,
+  DateTemplate.LAST_WEEK | DateTemplate.LAST_YEAR
+>;
+
+export type RankCache = UserFullProfile & UserRank;
+
+export type UserFullProfileMap = Map<UserPreview['id'], UserFullProfile>;
+export type RankingCacheMap = Map<UserPreview['id'], RankCache>;
+
+export type GetRankingArgs = {
+  keyBase: string;
+  dateTemplate: RankingSupportedDateTemplate;
+};
+
+export type GetRankArgs = GetRankingArgs & { userId: number };
+
+type QueryRankingByDateRangeFn = (dateRange: DateRange) => Promise<UserRank[]>;
+
+@Injectable()
+export class CacheUtilRankingService {
+  constructor(
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager: Cache,
+    private readonly cacheUtilService: CacheUtilService,
+    private readonly dateRangeService: DateRangeService,
+  ) {}
+
+  async getRank(args: GetRankArgs): Promise<RankCache | undefined> {
+    const rankCache = await this.getRawRank(args);
+    if (!rankCache) {
+      return undefined;
+    }
+
+    if (rankCache.value <= 0) {
+      return {
+        ...rankCache,
+        rank: 0,
+      };
+    }
+
+    return rankCache;
+  }
+
+  async getRanking(args: GetRankingArgs): Promise<RankCache[] | undefined> {
+    const rankingCache = await this.getRawRanking(args);
+    if (!rankingCache) {
+      return undefined;
+    }
+
+    const sliceIndex = rankingCache.findIndex((rank) => rank.value <= 0);
+
+    return rankingCache.slice(0, sliceIndex !== -1 ? sliceIndex : undefined);
+  }
+
+  async getRawRank({
+    keyBase,
+    userId,
+    dateTemplate,
+  }: GetRankArgs): Promise<RankCache | undefined> {
+    const key = this.cacheUtilService.buildKey(
+      keyBase,
+      DateTemplate[dateTemplate],
+    );
+
+    return await this.cacheUtilService.getMapValue(key, userId);
+  }
+
+  async getRawRanking({
+    keyBase,
+    dateTemplate,
+  }: GetRankingArgs): Promise<RankCache[] | undefined> {
+    const key = this.cacheUtilService.buildKey(
+      keyBase,
+      DateTemplate[dateTemplate],
+    );
+
+    const rankingCache = await this.cacheUtilService
+      .getMapValues<RankCache>(key)
+      .then((ranking) => ranking?.sort((a, b) => a.rank - b.rank));
+
+    if (!rankingCache) {
+      return undefined;
+    }
+
+    return rankingCache;
+  }
+
+  async updateCursusUserRanking({
+    userFullProfiles,
+    keyBase,
+    updatedAt,
+    valueExtractor,
+  }: {
+    userFullProfiles: UserFullProfile[];
+    keyBase: string;
+    updatedAt: Date;
+    valueExtractor: (userFullProfile: UserFullProfile) => number;
+  }): Promise<void> {
+    const key = this.cacheUtilService.buildKey(
+      keyBase,
+      DateTemplate[DateTemplate.TOTAL],
+    );
+
+    const rankingMap: RankingCacheMap = new Map();
+
+    userFullProfiles.forEach((userFullProfile) => {
+      rankingMap.set(userFullProfile.cursusUser.user.id, {
+        ...userFullProfile,
+        userPreview: toUserPreviewFromFullProfile(userFullProfile),
+        value: valueExtractor(userFullProfile),
+        rank: -1,
+      });
+    });
+
+    fixRanking(rankingMap);
+
+    await this.cacheUtilService.setWithDate(key, rankingMap, updatedAt);
+  }
+
+  async updateRanking({
+    userFullProfiles,
+    keyBase,
+    newUpdatedAt,
+    dateTemplate,
+    queryRankingFn,
+    sortFn,
+  }: {
+    userFullProfiles: UserFullProfile[];
+    keyBase: string;
+    newUpdatedAt: Date;
+    dateTemplate: RankingSupportedDateTemplate;
+    queryRankingFn: QueryRankingByDateRangeFn;
+    sortFn?: Parameters<RankCache[]['sort']>[0];
+  }): Promise<void> {
+    const key = this.cacheUtilService.buildKey(
+      keyBase,
+      DateTemplate[dateTemplate],
+    );
+
+    const newRankingCacheMap = generateEmptyRankingCacheMap(userFullProfiles);
+    const updatedRanking = await this.generateUpdatedRanking(
+      key,
+      newUpdatedAt,
+      dateTemplate,
+      queryRankingFn,
+    );
+
+    this.mergeRankingCacheToMap(newRankingCacheMap, updatedRanking, sortFn);
+
+    await this.cacheUtilService.setWithDate(
+      key,
+      newRankingCacheMap,
+      newUpdatedAt,
+    );
+  }
+
+  private async generateUpdatedRanking(
+    key: string,
+    newUpdatedAt: Date,
+    dateTemplate: RankingSupportedDateTemplate,
+    queryRankingFn: QueryRankingByDateRangeFn,
+  ): Promise<UserRank[]> {
+    const cached = await this.cacheManager.get<CacheWithDate<RankingCacheMap>>(
+      key,
+    );
+
+    if (cached && isUpToDate(cached.updatedAt, newUpdatedAt, dateTemplate)) {
+      return [...cached.data.values()];
+    }
+
+    const dateRange = this.dateRangeService.dateRangeFromTemplate(dateTemplate);
+
+    if (cached && isReusable(cached.updatedAt, dateTemplate)) {
+      dateRange.start = cached.updatedAt;
+
+      const newUserRanking = await queryRankingFn(dateRange);
+      this.mergeRankingCacheToMap(cached.data, newUserRanking);
+
+      return [...cached.data.values()];
+    }
+
+    return await queryRankingFn(dateRange);
+  }
+
+  private mergeRankingCacheToMap(
+    rankingCacheMap: RankingCacheMap,
+    userRanking: UserRank[],
+    sortFn?: Parameters<RankCache[]['sort']>[0],
+  ): void {
+    userRanking.forEach((userRank) => {
+      const prev = rankingCacheMap.get(userRank.userPreview.id);
+      assertExist(prev);
+
+      prev.value += userRank.value;
+    });
+
+    fixRanking(rankingCacheMap, sortFn);
+  }
+}
+
+const isReusable = (
+  cacheUpdatedAt: Date,
+  dateTemplate: RankingSupportedDateTemplate,
+): boolean => {
+  switch (dateTemplate) {
+    case DateTemplate.TOTAL:
+      return true;
+    case DateTemplate.CURR_WEEK:
+      return (
+        cacheUpdatedAt.getTime() >= DateWrapper.currWeek().toDate().getTime()
+      );
+    case DateTemplate.CURR_MONTH:
+      return (
+        cacheUpdatedAt.getTime() >= DateWrapper.currMonth().toDate().getTime()
+      );
+    default:
+      return false;
+  }
+};
+
+const isUpToDate = (
+  cacheUpdatedAt: Date,
+  newUpdatedAt: Date,
+  dateTemplate: RankingSupportedDateTemplate,
+): boolean => {
+  switch (dateTemplate) {
+    case DateTemplate.TOTAL:
+    case DateTemplate.CURR_WEEK:
+    case DateTemplate.CURR_MONTH:
+      return cacheUpdatedAt.getTime() === newUpdatedAt.getTime();
+    case DateTemplate.LAST_MONTH:
+      return (
+        cacheUpdatedAt.getTime() === DateWrapper.lastMonth().toDate().getTime()
+      );
+    default:
+      return false;
+  }
+};
+
+const generateEmptyRankingCacheMap = (
+  userFullProfiles: UserFullProfile[],
+): RankingCacheMap => {
+  return userFullProfiles.reduce((map, userFullProfile) => {
+    map.set(userFullProfile.cursusUser.user.id, generateRank(userFullProfile));
+
+    return map;
+  }, new Map() as RankingCacheMap);
+};
+
+const generateRank = (
+  userFullProfile: UserFullProfile,
+  value?: number,
+  rank?: number,
+): RankCache => ({
+  ...userFullProfile,
+  userPreview: toUserPreviewFromFullProfile(userFullProfile),
+  rank: rank ?? 0,
+  value: value ?? 0,
+});
+
+const fixRanking = (
+  rankingCacheMap: RankingCacheMap,
+  sortFn: Parameters<RankCache[]['sort']>[0] = (a, b) => b.value - a.value,
+): void => {
+  [...rankingCacheMap.values()].sort(sortFn).reduce(
+    ({ prevRank, prevValue }, userRank, index) => {
+      userRank.rank = prevValue === userRank.value ? prevRank : index + 1;
+
+      return { prevRank: userRank.rank, prevValue: userRank.value };
+    },
+    { prevRank: 0, prevValue: Number.MIN_SAFE_INTEGER },
+  );
+};

--- a/app/src/cache/cache.util.ranking.service.ts
+++ b/app/src/cache/cache.util.ranking.service.ts
@@ -108,11 +108,13 @@ export class CacheUtilRankingService {
     keyBase,
     updatedAt,
     valueExtractor,
+    userFilter,
   }: {
     userFullProfiles: UserFullProfile[];
     keyBase: string;
     updatedAt: Date;
     valueExtractor: (userFullProfile: UserFullProfile) => number;
+    userFilter?: (userFullProfile: UserFullProfile) => boolean;
   }): Promise<void> {
     const key = this.cacheUtilService.buildKey(
       keyBase,
@@ -122,6 +124,10 @@ export class CacheUtilRankingService {
     const rankingMap: RankingCacheMap = new Map();
 
     userFullProfiles.forEach((userFullProfile) => {
+      if (userFilter && userFilter(userFullProfile)) {
+        return;
+      }
+
       rankingMap.set(userFullProfile.cursusUser.user.id, {
         ...userFullProfile,
         userPreview: toUserPreviewFromFullProfile(userFullProfile),

--- a/app/src/cache/cache.util.service.ts
+++ b/app/src/cache/cache.util.service.ts
@@ -1,14 +1,8 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable } from '@nestjs/common';
 import type { Cache } from 'cache-manager';
-import type { UserFullProfile } from 'src/api/cursusUser/cursusUser.service';
-import { assertExist } from 'src/common/assertExist';
-import type {
-  UserPreview,
-  UserRank,
-} from 'src/common/models/common.user.model';
-import { DateRangeService } from 'src/dateRange/dateRange.service';
-import { DateTemplate, type DateRange } from 'src/dateRange/dtos/dateRange.dto';
+import type { UserPreview } from 'src/common/models/common.user.model';
+import type { UserFullProfile } from 'src/common/userFullProfile';
 import { DateWrapper } from 'src/statDate/StatDate';
 
 const USER_FULL_PROFILE = 'userFullProfile';
@@ -18,31 +12,13 @@ export type CacheWithDate<T> = {
   updatedAt: Date;
 };
 
-export type CacheSupportedDateTemplate = Exclude<
-  DateTemplate,
-  DateTemplate.LAST_WEEK | DateTemplate.LAST_YEAR
->;
-
-export type RankCache = UserFullProfile & UserRank;
-
 export type UserFullProfileMap = Map<UserPreview['id'], UserFullProfile>;
-export type RankingCacheMap = Map<UserPreview['id'], RankCache>;
-
-export type GetRankingArgs = {
-  keyBase: string;
-  dateTemplate: CacheSupportedDateTemplate;
-};
-
-export type GetRankArgs = GetRankingArgs & { userId: number };
-
-type QueryRankingByDateRangeFn = (dateRange: DateRange) => Promise<UserRank[]>;
 
 @Injectable()
 export class CacheUtilService {
   constructor(
     @Inject(CACHE_MANAGER)
     private readonly cacheManager: Cache,
-    private readonly dateRangeService: DateRangeService,
   ) {}
 
   async get<T>(key: string): Promise<T | undefined> {
@@ -76,14 +52,11 @@ export class CacheUtilService {
     return await this.getWithoutDate<Map<K, V>>(key);
   }
 
-  private async getMapValue<K, V>(
-    key: string,
-    elemKey: K,
-  ): Promise<V | undefined> {
+  async getMapValue<K, V>(key: string, elemKey: K): Promise<V | undefined> {
     return await this.getMap<K, V>(key).then((map) => map?.get(elemKey));
   }
 
-  private async getMapValues<V>(key: string): Promise<V[] | undefined> {
+  async getMapValues<V>(key: string): Promise<V[] | undefined> {
     return await this.getMap<unknown, V>(key).then((map) =>
       map ? [...map.values()] : undefined,
     );
@@ -106,60 +79,6 @@ export class CacheUtilService {
     return this.getWithoutDate<UserFullProfileMap>(USER_FULL_PROFILE);
   }
 
-  async getRank(args: GetRankArgs): Promise<RankCache | undefined> {
-    const rankCache = await this.getRawRank(args);
-    if (!rankCache) {
-      return undefined;
-    }
-
-    if (rankCache.value <= 0) {
-      return {
-        ...rankCache,
-        rank: 0,
-      };
-    }
-
-    return rankCache;
-  }
-
-  async getRanking(args: GetRankingArgs): Promise<RankCache[] | undefined> {
-    const rankingCache = await this.getRawRanking(args);
-    if (!rankingCache) {
-      return undefined;
-    }
-
-    const sliceIndex = rankingCache.findIndex((rank) => rank.value <= 0);
-
-    return rankingCache.slice(0, sliceIndex !== -1 ? sliceIndex : undefined);
-  }
-
-  async getRawRank({
-    keyBase,
-    userId,
-    dateTemplate,
-  }: GetRankArgs): Promise<RankCache | undefined> {
-    const key = this.buildKey(keyBase, DateTemplate[dateTemplate]);
-
-    return await this.getMapValue(key, userId);
-  }
-
-  async getRawRanking({
-    keyBase,
-    dateTemplate,
-  }: GetRankingArgs): Promise<RankCache[] | undefined> {
-    const key = this.buildKey(keyBase, DateTemplate[dateTemplate]);
-
-    const rankingCache = await this.getMapValues<RankCache>(key).then(
-      (ranking) => ranking?.sort((a, b) => a.rank - b.rank),
-    );
-
-    if (!rankingCache) {
-      return undefined;
-    }
-
-    return rankingCache;
-  }
-
   async setUserFullProfiles(
     userFullProfiles: UserFullProfile[],
     updatedAt: Date,
@@ -176,160 +95,7 @@ export class CacheUtilService {
     await this.setWithDate(USER_FULL_PROFILE, userFullProfileMap, updatedAt);
   }
 
-  async updateRanking({
-    keyBase,
-    newUpdatedAt,
-    dateTemplate,
-    queryRankingFn,
-    sortFn,
-  }: {
-    keyBase: string;
-    newUpdatedAt: Date;
-    dateTemplate: CacheSupportedDateTemplate;
-    queryRankingFn: QueryRankingByDateRangeFn;
-    sortFn?: Parameters<RankCache[]['sort']>[0];
-  }): Promise<void> {
-    const key = this.buildKey(keyBase, DateTemplate[dateTemplate]);
-
-    const updatedRanking = await this.generateUpdatedRanking(
-      key,
-      newUpdatedAt,
-      dateTemplate,
-      queryRankingFn,
-    );
-
-    this.fixRanking(updatedRanking, sortFn);
-
-    await this.setWithDate(key, updatedRanking, newUpdatedAt);
-  }
-
-  private async generateUpdatedRanking(
-    key: string,
-    newUpdatedAt: Date,
-    dateTemplate: CacheSupportedDateTemplate,
-    queryRankingFn: QueryRankingByDateRangeFn,
-  ): Promise<RankingCacheMap> {
-    const cached = await this.cacheManager.get<CacheWithDate<RankingCacheMap>>(
-      key,
-    );
-
-    if (cached) {
-      if (isUpToDate(cached.updatedAt, newUpdatedAt, dateTemplate)) {
-        return cached.data;
-      }
-
-      if (isReusable(cached.updatedAt, dateTemplate)) {
-        const dateRange =
-          this.dateRangeService.dateRangeFromTemplate(dateTemplate);
-
-        dateRange.start = cached.updatedAt;
-
-        const newUserRanking = await queryRankingFn(dateRange);
-        const newRankingCache = await this.toRankingCache(newUserRanking);
-
-        return this.mergeRankingCacheToMap(cached.data, newRankingCache);
-      }
-    }
-
-    const dateRange = this.dateRangeService.dateRangeFromTemplate(dateTemplate);
-
-    const newRanking = await queryRankingFn(dateRange);
-    const rankingCache = await this.toRankingCache(newRanking);
-
-    return rankingCache.reduce((rankingCacheMap, rankCache) => {
-      rankingCacheMap.set(rankCache.cursusUser.user.id, rankCache);
-
-      return rankingCacheMap;
-    }, new Map() as RankingCacheMap);
-  }
-
-  private async toRankingCache(userRanking: UserRank[]): Promise<RankCache[]> {
-    const userFullProfileMap = await this.getUserFullProfileMap();
-    assertExist(userFullProfileMap);
-
-    return userRanking.map((userRank) => {
-      const userFullProfile = userFullProfileMap.get(userRank.userPreview.id);
-      assertExist(userFullProfile);
-
-      return {
-        ...userFullProfile,
-        ...userRank,
-      };
-    });
-  }
-
-  private mergeRankingCacheToMap(
-    rankingCacheMap: RankingCacheMap,
-    rankingCache: RankCache[],
-  ): RankingCacheMap {
-    rankingCache.forEach((rankCache) => {
-      const prev = rankingCacheMap.get(rankCache.cursusUser.user.id);
-
-      if (prev) {
-        prev.value += rankCache.value;
-        return;
-      }
-
-      rankingCacheMap.set(rankCache.cursusUser.user.id, rankCache);
-    });
-
-    return rankingCacheMap;
-  }
-
   buildKey(...args: string[]): string {
     return args.join(':');
   }
-
-  fixRanking(
-    rankingCacheMap: RankingCacheMap,
-    sortFn: Parameters<RankCache[]['sort']>[0] = (a, b) => b.value - a.value,
-  ): void {
-    [...rankingCacheMap.values()].sort(sortFn).reduce(
-      ({ prevRank, prevValue }, userRank, index) => {
-        userRank.rank = prevValue === userRank.value ? prevRank : index + 1;
-
-        return { prevRank: userRank.rank, prevValue: userRank.value };
-      },
-      { prevRank: 0, prevValue: Number.MIN_SAFE_INTEGER },
-    );
-  }
 }
-
-const isReusable = (
-  cacheUpdatedAt: Date,
-  dateTemplate: CacheSupportedDateTemplate,
-): boolean => {
-  switch (dateTemplate) {
-    case DateTemplate.TOTAL:
-      return true;
-    case DateTemplate.CURR_WEEK:
-      return (
-        cacheUpdatedAt.getTime() >= DateWrapper.currWeek().toDate().getTime()
-      );
-    case DateTemplate.CURR_MONTH:
-      return (
-        cacheUpdatedAt.getTime() >= DateWrapper.currMonth().toDate().getTime()
-      );
-    default:
-      return false;
-  }
-};
-
-const isUpToDate = (
-  cacheUpdatedAt: Date,
-  newUpdatedAt: Date,
-  dateTemplate: CacheSupportedDateTemplate,
-): boolean => {
-  switch (dateTemplate) {
-    case DateTemplate.TOTAL:
-    case DateTemplate.CURR_WEEK:
-    case DateTemplate.CURR_MONTH:
-      return cacheUpdatedAt.getTime() === newUpdatedAt.getTime();
-    case DateTemplate.LAST_MONTH:
-      return (
-        cacheUpdatedAt.getTime() === DateWrapper.lastMonth().toDate().getTime()
-      );
-    default:
-      return false;
-  }
-};

--- a/app/src/common/userFullProfile.ts
+++ b/app/src/common/userFullProfile.ts
@@ -1,0 +1,23 @@
+import type { Coalition } from 'src/api/coalition/models/coalition.model';
+import type { cursus_user } from 'src/api/cursusUser/db/cursusUser.database.schema';
+import type { title } from 'src/api/title/db/title.database.schema';
+import type { titles_user } from 'src/api/titlesUser/db/titlesUser.database.schema';
+import type { UserPreview } from './models/common.user.model';
+
+export type UserFullProfile = {
+  cursusUser: cursus_user;
+  coalition?: Coalition;
+  titlesUsers: (titles_user & {
+    titles: title;
+  })[];
+};
+
+export const toUserPreviewFromFullProfile = (
+  userFullProfile: UserFullProfile,
+): UserPreview => {
+  return {
+    id: userFullProfile.cursusUser.user.id,
+    login: userFullProfile.cursusUser.user.login,
+    imgUrl: userFullProfile.cursusUser.user.image.link,
+  };
+};

--- a/app/src/lambda/lambda.service.ts
+++ b/app/src/lambda/lambda.service.ts
@@ -4,7 +4,10 @@ import {
   USER_LEVEL_RANKING,
   USER_WALLET_RANKING,
 } from 'src/api/cursusUser/cursusUser.cache.service';
-import { CursusUserService } from 'src/api/cursusUser/cursusUser.service';
+import {
+  CursusUserService,
+  isBlackholed,
+} from 'src/api/cursusUser/cursusUser.service';
 import { expIncreamentDateFilter } from 'src/api/experienceUser/db/experiecneUser.database.aggregate';
 import { EXP_INCREAMENT_RANKING } from 'src/api/experienceUser/experienceUser.cache.service';
 import { ExperienceUserService } from 'src/api/experienceUser/experienceUser.service';
@@ -86,6 +89,7 @@ export class LambdaService {
       keyBase: USER_CORRECTION_POINT_RANKING,
       updatedAt,
       valueExtractor: ({ cursusUser }) => cursusUser.user.correctionPoint,
+      userFilter: ({ cursusUser }) => isBlackholed(cursusUser),
     });
 
     await this.updateEvalCountRanking(

--- a/app/src/page/leaderboard/util/leaderboard.util.service.ts
+++ b/app/src/page/leaderboard/util/leaderboard.util.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import type {
-  CacheSupportedDateTemplate,
+  RankingSupportedDateTemplate,
   RankCache,
-} from 'src/cache/cache.util.service';
+} from 'src/cache/cache.util.ranking.service';
 import { DateRangeService } from 'src/dateRange/dateRange.service';
 import { DateTemplate } from 'src/dateRange/dtos/dateRange.dto';
 import type { PaginationIndexArgs } from 'src/pagination/index/dtos/pagination.index.dto.args';
@@ -22,7 +22,7 @@ import type {
 // RankType extends UserRank = UserRank
 
 export type RankingByDateTemplateArgs<
-  SupportDateTemplate extends DateTemplate = CacheSupportedDateTemplate,
+  SupportDateTemplate extends DateTemplate = RankingSupportedDateTemplate,
 > = {
   userId: number;
   paginationIndexArgs: PaginationIndexArgs;
@@ -30,7 +30,7 @@ export type RankingByDateTemplateArgs<
 };
 
 export type LeaderboardElementConvertorArgs<
-  SupportDateTemplate extends DateTemplate = CacheSupportedDateTemplate,
+  SupportDateTemplate extends DateTemplate = RankingSupportedDateTemplate,
 > = {
   rank: RankCache | undefined;
   ranking: RankCache[];
@@ -47,7 +47,7 @@ export class LeaderboardUtilService {
   ) {}
 
   async toLeaderboardElementDateRanged<
-    SupportDateTemplate extends DateTemplate = CacheSupportedDateTemplate,
+    SupportDateTemplate extends DateTemplate = RankingSupportedDateTemplate,
   >({
     rank,
     ranking,

--- a/app/src/page/myInfo/myInfo.service.ts
+++ b/app/src/page/myInfo/myInfo.service.ts
@@ -2,7 +2,6 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import type { FilterQuery } from 'mongoose';
 import { CursusUserCacheService } from 'src/api/cursusUser/cursusUser.cache.service';
 import { CursusUserService } from 'src/api/cursusUser/cursusUser.service';
-import type { cursus_user } from 'src/api/cursusUser/db/cursusUser.database.schema';
 import type { experience_user } from 'src/api/experienceUser/db/experienceUser.database.schema';
 import { ExperienceUserCacheService } from 'src/api/experienceUser/experienceUser.cache.service';
 import { ExperienceUserService } from 'src/api/experienceUser/experienceUser.service';

--- a/app/src/page/personal/util/personal.util.service.ts
+++ b/app/src/page/personal/util/personal.util.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { CursusUserService } from 'src/api/cursusUser/cursusUser.service';
-import type { cursus_user } from 'src/api/cursusUser/db/cursusUser.database.schema';
 
 @Injectable()
 export class PersonalUtilService {


### PR DESCRIPTION
기존 랭킹 구하는 방식이, user full profile 이 변경된 경우에 적절히 대응이 되지 않던 문제가 있어,
이를 수정 하면서 파일 분리도 진행했습니다.