### PR TITLE
feat: :sparkles: personal general 에 dailyActivities 추가

### DIFF
--- a/app/src/api/event/db/event.database.aggregate.ts
+++ b/app/src/api/event/db/event.database.aggregate.ts
@@ -1,0 +1,11 @@
+import {
+  lookupStage,
+  type CollectionLookup,
+} from 'src/database/mongoose/database.mongoose.aggregation';
+import { events } from './event.database.schema';
+
+export const lookupEvents: CollectionLookup = (
+  localField,
+  foreignField,
+  pipeline,
+) => lookupStage(events.name, localField, foreignField, pipeline);

--- a/app/src/api/event/db/event.database.schema.ts
+++ b/app/src/api/event/db/event.database.schema.ts
@@ -1,0 +1,27 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import type { HydratedDocument } from 'mongoose';
+
+export type eventDocument = HydratedDocument<events>;
+
+@Schema({ collection: 'events' })
+export class events {
+  @Prop({ required: true })
+  id: number;
+
+  @Prop({ required: true })
+  beginAt: Date;
+
+  @Prop({ required: true })
+  endAt: Date;
+
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true })
+  description: string;
+
+  @Prop({ required: true })
+  location: string;
+}
+
+export const eventSchema = SchemaFactory.createForClass(events);

--- a/app/src/api/eventsUser/db/eventsUser.database.aggregate.ts
+++ b/app/src/api/eventsUser/db/eventsUser.database.aggregate.ts
@@ -1,0 +1,11 @@
+import {
+  lookupStage,
+  type CollectionLookup,
+} from 'src/database/mongoose/database.mongoose.aggregation';
+import { events_users } from './eventsUser.database.schema';
+
+export const lookupEventsUsers: CollectionLookup = (
+  localField,
+  foreignField,
+  pipeline,
+) => lookupStage(events_users.name, localField, foreignField, pipeline);

--- a/app/src/api/eventsUser/db/eventsUser.database.schema.ts
+++ b/app/src/api/eventsUser/db/eventsUser.database.schema.ts
@@ -1,0 +1,13 @@
+import { Prop, Schema } from '@nestjs/mongoose';
+
+@Schema({ collection: 'events_users' })
+export class events_users {
+  @Prop({ required: true })
+  id: number;
+
+  @Prop({ required: true })
+  eventId: number;
+
+  @Prop({ required: true })
+  userId: number;
+}

--- a/app/src/app.module.ts
+++ b/app/src/app.module.ts
@@ -59,7 +59,7 @@ import { TeamInfoModule } from './page/teamInfo/teamInfo.module';
     CacheModule.register({
       isGlobal: true,
       store: new ShallowStore({
-        max: 100000,
+        max: 10000000,
         ttl: DateWrapper.MIN * 3,
       }),
     }),

--- a/app/src/dailyActivity/dailyActivity.dto.ts
+++ b/app/src/dailyActivity/dailyActivity.dto.ts
@@ -1,0 +1,28 @@
+export enum DailyActivityType {
+  CORRECTOR,
+  CORRECTED,
+  EVENT,
+  LOGTIME,
+}
+
+export type DailyLogtimeRecord = {
+  type: DailyActivityType.LOGTIME;
+  value: number;
+  date: Date;
+};
+
+export type DailyDefaultRecord = {
+  type: Exclude<DailyActivityType, DailyActivityType.LOGTIME>;
+  id: number;
+  at: Date;
+};
+
+export type FindDailyActivityRecordInput = {
+  userId: number;
+  start: Date;
+  end: Date;
+};
+
+export type FindDailyActivityRecordOutput =
+  | DailyLogtimeRecord
+  | DailyDefaultRecord;

--- a/app/src/dailyActivity/dailyActivity.module.ts
+++ b/app/src/dailyActivity/dailyActivity.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import {
+  ScaleTeamSchema,
+  scale_team,
+} from 'src/api/scaleTeam/db/scaleTeam.database.schema';
+import { DailyActivityDaoImpl } from './db/dailyActivity.database.dao';
+import { DailyActivityService } from './dailyActivity.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: scale_team.name, schema: ScaleTeamSchema },
+    ]),
+  ],
+  providers: [DailyActivityDaoImpl, DailyActivityService],
+  exports: [DailyActivityService],
+})
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class DailyActivityModule {}

--- a/app/src/dailyActivity/dailyActivity.service.ts
+++ b/app/src/dailyActivity/dailyActivity.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import type { DateRange } from 'src/dateRange/dtos/dateRange.dto';
+import { DateWrapper } from 'src/dateWrapper/dateWrapper';
+import type { DailyActivity } from 'src/page/personal/general/models/personal.general.dailyActivity.model';
+import { DailyActivityDaoImpl } from './db/dailyActivity.database.dao';
+import {
+  DailyActivityType,
+  type DailyDefaultRecord,
+  type DailyLogtimeRecord,
+} from './dailyActivity.dto';
+
+@Injectable()
+export class DailyActivityService {
+  constructor(private readonly dailyActivityDao: DailyActivityDaoImpl) {}
+
+  async findAllUserDailyActivityByDate(
+    userId: number,
+    { start, end }: DateRange,
+  ): Promise<DailyActivity[]> {
+    const records = await this.dailyActivityDao.findAllRecordByDate({
+      userId,
+      start,
+      end,
+    });
+
+    const recordMapByDate = records.reduce((recordMap, record) => {
+      if (isDailyLogtimeRecord(record)) {
+        const timestamp = record.date.getTime();
+        const prevRecords = recordMap.get(timestamp) ?? [];
+
+        recordMap.set(timestamp, [
+          ...prevRecords,
+          { type: record.type, value: record.value },
+        ]);
+
+        return recordMap;
+      }
+
+      const timestamp = new DateWrapper(record.at)
+        .startOfDate()
+        .toDate()
+        .getTime();
+
+      const prevRecords = recordMap.get(timestamp) ?? [];
+
+      recordMap.set(timestamp, [...prevRecords, record]);
+
+      return recordMap;
+    }, new Map<number, DailyActivity['records']>());
+
+    return Array.from(recordMapByDate.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([timestamp, records]) => ({
+        date: new Date(timestamp),
+        records,
+      }));
+  }
+}
+
+const isDailyLogtimeRecord = (
+  record: DailyLogtimeRecord | DailyDefaultRecord,
+): record is DailyLogtimeRecord => record.type === DailyActivityType.LOGTIME;

--- a/app/src/dailyActivity/db/dailyActivity.database.dao.ts
+++ b/app/src/dailyActivity/db/dailyActivity.database.dao.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import type { Model } from 'mongoose';
+import { daily_logtimes } from 'src/dailyLogtime/db/dailyLogtime.database.schema';
+import { lookupEvents } from 'src/api/event/db/event.database.aggregate';
+import { events } from 'src/api/event/db/event.database.schema';
+import { events_users } from 'src/api/eventsUser/db/eventsUser.database.schema';
+import { scale_team } from 'src/api/scaleTeam/db/scaleTeam.database.schema';
+import {
+  DailyActivityType,
+  type DailyDefaultRecord,
+  type DailyLogtimeRecord,
+  type FindDailyActivityRecordInput,
+  type FindDailyActivityRecordOutput,
+} from '../dailyActivity.dto';
+
+export type DailyActivityDao = {
+  findAllRecordByDate: (
+    args: FindDailyActivityRecordInput,
+  ) => Promise<FindDailyActivityRecordOutput[]>;
+};
+
+@Injectable()
+export class DailyActivityDaoImpl implements DailyActivityDao {
+  constructor(
+    @InjectModel(scale_team.name)
+    private readonly scaleTeamModel: Model<scale_team>,
+  ) {}
+
+  async findAllRecordByDate({
+    userId,
+    start,
+    end,
+  }: FindDailyActivityRecordInput): Promise<FindDailyActivityRecordOutput[]> {
+    return await this.scaleTeamModel
+      .aggregate<DailyLogtimeRecord | DailyDefaultRecord>()
+      .match({
+        $or: [{ 'corrector.id': userId }, { 'correcteds.id': userId }],
+        filledAt: {
+          $gte: start,
+          $lt: end,
+        },
+      })
+      .sort({ filledAt: 1 })
+      .project({
+        _id: 0,
+        id: 1,
+        at: '$filledAt',
+        type: {
+          $cond: {
+            if: { $eq: ['$corrector.id', userId] },
+            then: DailyActivityType.CORRECTOR,
+            else: DailyActivityType.CORRECTED,
+          },
+        },
+      })
+      .unionWith({
+        coll: daily_logtimes.name,
+        pipeline: [
+          {
+            $match: {
+              userId,
+              date: {
+                $gte: start,
+                $lt: end,
+              },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              date: '$date',
+              type: { $literal: DailyActivityType.LOGTIME },
+              value: 1,
+            },
+          },
+        ],
+      })
+      .unionWith({
+        coll: events_users.name,
+        pipeline: [
+          {
+            $match: {
+              userId,
+            },
+          },
+          lookupEvents('eventId', 'id', [
+            {
+              $match: {
+                date: {
+                  $gte: start,
+                  $lt: end,
+                },
+              },
+            },
+          ]),
+          {
+            $project: {
+              _id: 0,
+              id: 1,
+              at: { $first: `$${events.name}.endAt` },
+              type: { $literal: DailyActivityType.EVENT },
+            },
+          },
+          {
+            $match: {
+              at: { $ne: null },
+            },
+          },
+          {
+            $sort: {
+              at: 1,
+            },
+          },
+        ],
+      });
+  }
+}

--- a/app/src/dailyLogtime/db/dailyLogtime.database.schema.ts
+++ b/app/src/dailyLogtime/db/dailyLogtime.database.schema.ts
@@ -1,0 +1,18 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import type { HydratedDocument } from 'mongoose';
+
+export type DailyLogtimeDocument = HydratedDocument<daily_logtimes>;
+
+@Schema({ collection: 'daily_logtimes' })
+export class daily_logtimes {
+  @Prop({ required: true })
+  userId: number;
+
+  @Prop({ required: true })
+  date: Date;
+
+  @Prop({ required: true })
+  value: number;
+}
+
+export const dailyLogtimeSchema = SchemaFactory.createForClass(daily_logtimes);

--- a/app/src/dateRange/dateRange.service.ts
+++ b/app/src/dateRange/dateRange.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { DateWrapper } from 'src/dateWrapper/dateWrapper';
-import { DateRangeArgs, DateTemplate } from './dtos/dateRange.dto';
+import { DateRange, DateRangeArgs, DateTemplate } from './dtos/dateRange.dto';
 import type { IDateRangedType } from './models/dateRange.model';
 
 @Injectable()
@@ -54,5 +54,22 @@ export class DateRangeService {
       $gte: start,
       $lt: end,
     };
+  }
+
+  getAbsoluteDateRangeByYear(year: number): DateRange {
+    const start = DateWrapper.createByYear(year).startOfYear().toDate();
+    const end = DateWrapper.createByYear(year)
+      .startOfYear()
+      .moveYear(1)
+      .toDate();
+
+    return { start, end };
+  }
+
+  getRelativeDateRange(): DateRange {
+    const start = new DateWrapper().startOfDate().moveDate(-364).toDate();
+    const end = new DateWrapper().startOfDate().moveDate(1).toDate();
+
+    return { start, end };
   }
 }

--- a/app/src/dateWrapper/dateWrapper.ts
+++ b/app/src/dateWrapper/dateWrapper.ts
@@ -111,4 +111,10 @@ export class DateWrapper {
   static currWeek = (): DateWrapper => new DateWrapper().startOfWeek();
   static lastWeek = (): DateWrapper => DateWrapper.currWeek().moveWeek(-1);
   static nextWeek = (): DateWrapper => DateWrapper.currWeek().moveWeek(1);
+
+  static currYear = (): DateWrapper => new DateWrapper().startOfYear();
+
+  static createByYear = (year: number): DateWrapper => {
+    return new DateWrapper(`${year - 1}-12-31T15:00:00.000Z`);
+  };
 }

--- a/app/src/page/personal/general/models/personal.general.dailyActivity.model.ts
+++ b/app/src/page/personal/general/models/personal.general.dailyActivity.model.ts
@@ -1,0 +1,65 @@
+import {
+  ArgsType,
+  Field,
+  ObjectType,
+  createUnionType,
+  registerEnumType,
+} from '@nestjs/graphql';
+import { IsOptional, Max, Min } from 'class-validator';
+import { DailyActivityType } from 'src/dailyActivity/dailyActivity.dto';
+
+registerEnumType(DailyActivityType, {
+  name: 'DailyAcitivtyType',
+});
+
+@ObjectType()
+export class DailyLogtimeRecord {
+  @Field((_type) => DailyActivityType)
+  type: DailyActivityType.LOGTIME;
+
+  @Field()
+  value: number;
+}
+
+@ObjectType()
+export class DailyDefaultRecord {
+  @Field((_type) => DailyActivityType)
+  type: Exclude<DailyActivityType, DailyActivityType.LOGTIME>;
+
+  @Field()
+  id: number;
+
+  @Field()
+  at: Date;
+}
+
+const DailyActivityRecordUnion = createUnionType({
+  name: 'DailyActivityRecord',
+  types: () => [DailyLogtimeRecord, DailyDefaultRecord] as const,
+  resolveType: (value) => {
+    switch (value.type) {
+      case DailyActivityType.LOGTIME:
+        return DailyLogtimeRecord;
+      default:
+        return DailyDefaultRecord;
+    }
+  },
+});
+
+@ObjectType()
+export class DailyActivity {
+  @Field()
+  date: Date;
+
+  @Field((_type) => [DailyActivityRecordUnion])
+  records: (typeof DailyActivityRecordUnion)[];
+}
+
+@ArgsType()
+export class GetDailyActivitiesArgs {
+  @IsOptional()
+  @Min(2000)
+  @Max(2100)
+  @Field({ nullable: true })
+  year?: number;
+}

--- a/app/src/page/personal/general/models/personal.general.model.ts
+++ b/app/src/page/personal/general/models/personal.general.model.ts
@@ -3,6 +3,7 @@ import { ProjectPreview } from 'src/common/models/common.project.model';
 import { IntRecord } from 'src/common/models/common.valueRecord.model';
 import { DateRanged } from 'src/dateRange/models/dateRange.model';
 import { TeamStatus } from 'src/page/teamInfo/models/teamInfo.status.model';
+import { DailyActivity } from './personal.general.dailyActivity.model';
 import { Character } from '../character/models/personal.general.character.model';
 import { UserProfile } from './personal.general.userProfile.model';
 
@@ -141,4 +142,7 @@ export class PersonalGeneral {
 
   @Field({ nullable: true })
   character?: Character;
+
+  @Field((_type) => [DailyActivity])
+  dailyActivities: DailyActivity[];
 }

--- a/app/src/page/personal/general/personal.general.module.ts
+++ b/app/src/page/personal/general/personal.general.module.ts
@@ -8,6 +8,7 @@ import { ProjectsUserModule } from 'src/api/projectsUser/projectsUser.module';
 import { ScaleTeamModule } from 'src/api/scaleTeam/scaleTeam.module';
 import { ScoreModule } from 'src/api/score/score.module';
 import { TeamModule } from 'src/api/team/team.module';
+import { DailyActivityModule } from 'src/dailyActivity/dailyActivity.module';
 import { DateRangeModule } from 'src/dateRange/dateRange.module';
 import { PersonalUtilModule } from '../util/personal.util.module';
 import { PersonalGeneralCharacterModule } from './character/persoanl.general.character.module';
@@ -27,6 +28,7 @@ import { PersonalGeneralService } from './personal.general.service';
     ProjectModule,
     ExperienceUserModule,
     CoalitionsUserModule,
+    DailyActivityModule,
     DateRangeModule,
   ],
   providers: [PersonalGeneralResolver, PersonalGeneralService],

--- a/app/src/schema.gql
+++ b/app/src/schema.gql
@@ -308,6 +308,31 @@ type LeaderboardScore {
   byDateTemplate(pageSize: Int! = 10, pageNumber: Int! = 1, promo: Int, coalitionId: Int, dateTemplate: DateTemplate!): LeaderboardElementDateRanged!
 }
 
+type DailyActivity {
+  date: DateTime!
+  records: [DailyActivityRecord!]!
+}
+
+union DailyActivityRecord = DailyLogtimeRecord | DailyDefaultRecord
+
+type DailyLogtimeRecord {
+  type: DailyAcitivtyType!
+  value: Int!
+}
+
+enum DailyAcitivtyType {
+  CORRECTOR
+  CORRECTED
+  EVENT
+  LOGTIME
+}
+
+type DailyDefaultRecord {
+  type: DailyAcitivtyType!
+  id: Int!
+  at: DateTime!
+}
+
 type CharacterType {
   name: String!
   description: String!
@@ -401,6 +426,7 @@ type PersonalGeneral {
   promoLevelRecords: [LevelRecord!]!
   promoMemberLevelRecords: [LevelRecord!]!
   character: Character
+  dailyActivities(year: Int): [DailyActivity!]!
 }
 
 type MyRecentActivity {


### PR DESCRIPTION
- 기존과는 다른 구조로 제작하였습니다. 앞으로 db 정리하고 이런 방식으로 고치면 어떨까 하는 생각입니다.
- daily_logtimes collection 을 추가했습니다.
- scale_teams, events_users 로 인해 성능 저하가 심각한 수준이면 별도 collection 으로 분리할 예정입니다. 현재 자체 테스트에선 dev 기준 100 ~ 300ms 정도 나옵니다.

- close #388
- close #389

---
위에 언급된 '기존과 다른 구조' 에 대한 자세한 설명입니다. 확정되면 관련 이슈에 옮길 계획입니다.

### 기존 방식
- page/xxx 에 resolver, model, service 가 있음
- xxx/service 는 api/yyy 에 있는 db 로직이 대부분인 yyy/service 를 사용함

장점
- collection 에 상관없이 원하는 collection 을 page 에서 사용할 수 있음

단점
- page, api 라는 이름이 직관적이지 않음
- page resolver, service 에는 로직이 거의 없고, api service 에 db query 문을 포함한 대부분의 로직이 존재함
- 사용하는 타입들에 대한 정의가 없어 계층 간 의존성이 강함
- 캐싱이나 page service 에서 사용할 인자에 대한 처리등 계층별로 필요한 로직의 위치가 불분명함

### 새로운 방식
- page/xxx 에 resolver, model 만 존재함
  - model 에는 실제로 resolver 에서 필요한 type 들만 정의
    - 후술할 yyy/dto 에 있는 타입은 재활용 가능
  - caching 은 resolver 로 이동
  - 인자 검증, 설정도 resolver 에서 진행
- yyy 에 (api 폴더 아님) service, dto, dao 정의
  - dto 에 dao -> service, service -> resolver 에 필요한 타입들 모두 정의
  - dao 에 query 로직 작성
    - 반환 타입은 무조건 dto 에 있는 타입을 사용
    - dao, daoImpl 을 분리하여 이후 impl 만 변경하면 되도록 설계

장점
- 계층 간 분리가 이뤄짐
- 기존 api service 에 있던 로직을 분리

단점
- cache 의 경우 기존에 사용하던 decorator 가 제대로 작동하지 않을 것으로 보임
- 기존 preload 캐시를 생각해보면 dao 에 캐시가 여전히 필요할 것으로 보이긴 함
- 루트 레벨에 폴더가 매우 많아질 것, 대신 하나 하나의 깊이는 얕아짐

database schema 위치가 고민입니다.
1. database 폴더에 schema 전부 정의하기 (aggregation, filter 등 util 함수 포함)
  - 이게 제일 깔끔할 것 같긴 합니다
2. 적당히 yyy 들에 나눠서 만들기
  - 폴더 수를 많이 줄여줄 것으로 보입니다