### PR TITLE
fix: 🐛  activeUserCount 는 해당 월의 데이터가 없는 경우 0명으로 처리하도록 수정

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42stat",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "",
   "author": "jpham005, niamu01",
   "private": true,

--- a/app/src/activeUserCount/activeUserCount.service.ts
+++ b/app/src/activeUserCount/activeUserCount.service.ts
@@ -19,10 +19,6 @@ export class ActiveUserCountService {
     });
 
     const activeUserCountList = new Array<ActiveUserCount>();
-    let prevCount =
-      dbDataList
-        .filter((dbData) => dbData.date.getTime() < input.start.getTime())
-        .at(-1)?.count ?? 0;
 
     for (
       let curr = input.start;
@@ -35,10 +31,8 @@ export class ActiveUserCountService {
 
       activeUserCountList.push({
         date: curr,
-        count: dbData?.count ?? prevCount,
+        count: dbData?.count ?? 0,
       });
-
-      prevCount += dbData?.count ?? 0;
     }
 
     return activeUserCountList;


### PR DESCRIPTION
alive user 는 유저 수 변동이 없으면 이전 달의 수치를 가져오는 것이 맞지만,
active 는 유저 활동이 없으면 실제로 없는게 맞기 때문에 수정합니다.